### PR TITLE
Add min filter for jinja backwards compatibility

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -632,6 +632,8 @@ class FlowProject(six.with_metaclass(_FlowProjectClass, signac.contrib.Project))
         template_environment.filters['get_account_name'] = tf.get_account_name
         if 'max' not in template_environment.filters:    # for jinja2 < 2.10
             template_environment.filters['max'] = max
+        if 'min' not in template_environment.filters:    # for jinja2 < 2.10
+            template_environment.filters['min'] = min
         return template_environment
 
     def _template_environment(self, environment=None):


### PR DESCRIPTION
In our rewrite of the templates in December I think that we missed needing to add this for backwards compatibility.