### PR TITLE
Fix issue with TORQUE is_present() method triggering exception.

### DIFF
--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -142,6 +142,8 @@ class TorqueScheduler(Scheduler):
         "Return True if it appears that a TORQUE scheduler is available within the environment."
         try:
             subprocess.check_output(['qsub', '--version'], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            return True
         except (IOError, OSError):
             return False
         else:


### PR DESCRIPTION
Fixes issue #53 .

Possible point of contention: Should we consider the scheduler to *not* be present in case that it triggers an error? I think we should say it's present even if it's not usable, because we might still be able to query the status of running jobs.