### PR TITLE
Correctly determine the source file for wrapped functions.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -2512,7 +2512,7 @@ class FlowProject(six.with_metaclass(_FlowProjectClass, signac.contrib.Project))
             except (KeyError, TypeError):
                 executable = sys.executable
 
-            path = getattr(func, '_flow_path', inspect.getsourcefile(func))
+            path = getattr(func, '_flow_path', inspect.getsourcefile(inspect.getmodule(func)))
             cmd_str = "{} {} exec {} {{job._id}}"
 
             if callable(executable):


### PR DESCRIPTION
This patch fixes an issue where the source file, e.g., the project.py
file in which an operation function is define in, will not be correctly
detected in case that the function was wrapped with some kind of
decorator.

For example:

    # project.py
    from util import my_wrapper

    @Project.operation
    @my_wrapper
    def hello(job):
        pass

In case that my_wrapper redefines the function in util, the source
code file was previously detected to be util.py instead of project.py.