### PR TITLE
Fix/eos submission

### DIFF
--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -144,7 +144,8 @@ class TorqueScheduler(Scheduler):
             # some qsub wrappers don't run on no-tty
             import pty
             master, slave = pty.openpty()
-            subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave, shell=True)
+            subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave,
+                shell=True)
         except (IOError, OSError):
             return False
         else:

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -144,7 +144,7 @@ class TorqueScheduler(Scheduler):
             # some qsub wrappers don't run on no-tty
             import pty
             master, slave = pty.openpty()
-            subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave,
+            subprocess.Popen(['qsub', '--version'], stdin=slave, stdout=slave, stderr=slave,
                              shell=True)
         except (IOError, OSError):
             return False

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -141,7 +141,10 @@ class TorqueScheduler(Scheduler):
     def is_present(cls):
         "Return True if it appears that a TORQUE scheduler is available within the environment."
         try:
-            subprocess.check_output(['qsub', '--version'], stderr=subprocess.STDOUT)
+            # some qsub wrappers don't run on no-tty
+            import pty
+            master, slave = pty.openpty()
+            p = subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave, shell=True)
         except (IOError, OSError):
             return False
         else:

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -27,7 +27,7 @@ def _fetch(user=None):
     cmd = "qstat -fx -u {user}".format(user=user)
     try:
         result = io.BytesIO(subprocess.check_output(cmd.split()))
-    except FileNotFoundError:
+    except OSError:
         raise RuntimeError("Torque not available.")
     tree = ET.parse(source=result)
     return tree.getroot()

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -145,7 +145,7 @@ class TorqueScheduler(Scheduler):
             import pty
             master, slave = pty.openpty()
             subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave,
-                shell=True)
+                             shell=True)
         except (IOError, OSError):
             return False
         else:

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -144,7 +144,7 @@ class TorqueScheduler(Scheduler):
             # some qsub wrappers don't run on no-tty
             import pty
             master, slave = pty.openpty()
-            p = subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave, shell=True)
+            subprocess.Popen(['qsub', '--version'],stdin=slave, stdout=slave, stderr=slave, shell=True)
         except (IOError, OSError):
             return False
         else:

--- a/flow/templates/eos.sh
+++ b/flow/templates/eos.sh
@@ -7,7 +7,7 @@
 {% if operations|calc_tasks('ngpu', true, true) and not force %}
 {% raise "GPUs were requested but are unsupported by Eos!" %}
 {% endif %}
-{% set nn = nn|default(cpu_tasks|calc_num_nodes(24), true) %}
+{% set nn = nn|default(cpu_tasks|calc_num_nodes(32), true) %}
 #PBS -l nodes={{ nn|check_utilization(cpu_tasks, 24, threshold, 'CPU') }}
 {% endblock %}
 {% block header %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This fixes two issues when trying to submit MPI jobs on EOS.

1. EOS uses a qsub wrapper (a perl script), which expects to run inside a tty.
2. the # of ranks per node was wrong (it is 32, not 24)

## Description
ad 1. to honor the shebang (#1) line for perl of the qsub wrapper, apparently only subprocess.Popen works, but check_output does not. To additionally create a tty, one has to use python's pty lib.


## Motivation and Context
Trying to submit on OLCF eos.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [x] *master*, because it is a bug fix or an update to the documentation.
- [ ] *develop*, because it introduces a new feature.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
