### PR TITLE
Fix/eos incorrect node size

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ We recommend to go through the tutorial on signac-docs_ to learn how to best tak
 - Fixes issues with the Summit environment resource set calculation for parallel operations under specific conditions.
 - Remove the Ascent environment (host decomissioned).
 - Fixes issue where callable cmd-directives were not evaluated.
+- Fix the node size specified in the template for the ORNL Eos system.
 
 [0.6.4] -- 2018-12-28
 ---------------------

--- a/flow/templates/eos.sh
+++ b/flow/templates/eos.sh
@@ -7,8 +7,8 @@
 {% if operations|calc_tasks('ngpu', true, true) and not force %}
 {% raise "GPUs were requested but are unsupported by Eos!" %}
 {% endif %}
-{% set nn = nn|default(cpu_tasks|calc_num_nodes(24), true) %}
-#PBS -l nodes={{ nn|check_utilization(cpu_tasks, 24, threshold, 'CPU') }}
+{% set nn = nn|default(cpu_tasks|calc_num_nodes(32), true) %}
+#PBS -l nodes={{ nn|check_utilization(cpu_tasks, 32, threshold, 'CPU') }}
 {% endblock %}
 {% block header %}
 {{ super() -}}


### PR DESCRIPTION
The eos node size was set to 24 instead of the correct number: 32.