### PR TITLE
Fix py27 incompatiblity in torque schduler module.

### DIFF
--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -7,6 +7,7 @@ This module implements the Scheduler and ClusterJob classes for TORQUE.
 """
 from __future__ import print_function
 import io
+import errno
 import getpass
 import subprocess
 import tempfile
@@ -27,8 +28,11 @@ def _fetch(user=None):
     cmd = "qstat -fx -u {user}".format(user=user)
     try:
         result = io.BytesIO(subprocess.check_output(cmd.split()))
-    except FileNotFoundError:
-        raise RuntimeError("Torque not available.")
+    except (IOError, OSError) as error:
+        if error.errno == errno.ENOENT:
+            raise RuntimeError("Torque not available.")
+        else:
+            raise error
     tree = ET.parse(source=result)
     return tree.getroot()
 


### PR DESCRIPTION
Python 2.7 does not have `FileNotFoundError`.