### PR TITLE
Add clear environment notification when submitting job scripts.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,6 +18,15 @@
             "affiliation": "University of Michigan",
             "name": "Timothy Moore",
             "orcid": "0000-0002-5709-7259"
+        },
+        {
+            "affiliation": "University of Michigan",
+            "name": "Shannon Moran",
+            "orcid": "0000-0002-3579-3149"
+        },
+        {
+            "affiliation": "University of Michigan",
+            "name": "Yannah Melle"
         }
     ],
     "creators": [

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,11 @@ Changes
 
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 
+next
+----
+
+- Add clear environment notification when submitting job scripts.
+
 Version 0.7
 ===========
 

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -49,4 +49,13 @@ contributors:
     given-names: Timothy
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0002-5709-7259"
+  -
+    family-names: Moran
+    given-names: Shannon
+    affiliation: "University of Michigan"
+    orcid: "https://orcid.org/0000-0002-3579-3149"
+  -
+    family-names: Melle
+    given-names: Yannah
+    affiliation: "University of Michigan"
 ...

--- a/flow/project.py
+++ b/flow/project.py
@@ -2630,6 +2630,7 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
             '{} options'.format(self._environment.__name__))
         self._environment.add_args(env_group)
         parser_submit.set_defaults(func=self._main_submit)
+        print('Using environment configuration:', self._environment.__name__)
 
         parser_exec = subparsers.add_parser(
             'exec',

--- a/flow/project.py
+++ b/flow/project.py
@@ -2630,7 +2630,7 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
             '{} options'.format(self._environment.__name__))
         self._environment.add_args(env_group)
         parser_submit.set_defaults(func=self._main_submit)
-        print('Using environment configuration:', self._environment.__name__)
+        print('Using environment configuration:', self._environment.__name__, file=sys.stderr)
 
         parser_exec = subparsers.add_parser(
             'exec',

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -690,7 +690,11 @@ class ProjectMainInterfaceTest(BaseProjectTest):
         try:
             with add_path_to_environment_pythonpath(os.path.abspath(self.cwd)):
                 with switch_to_directory(self.project.root_directory()):
-                    return subprocess.check_output(_cmd.split(), stderr=subprocess.STDOUT)
+                    if six.PY2:
+                        with open(os.devnull, 'w') as devnull:
+                            return subprocess.check_output(_cmd.split(), stderr=devnull)
+                    else:
+                        return subprocess.check_output(_cmd.split(), stderr=subprocess.DEVNULL)
         except subprocess.CalledProcessError as error:
             print(error, file=sys.stderr)
             print(error.output, file=sys.stderr)


### PR DESCRIPTION
## Description
Adds short print message that displays the current environment configuration whenever a job script is run.

## Motivation and Context
This addresses issue #43. We implemented a command line notification solution versus introducing a new trouble-shooting flow in the documentation.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [ ] *master*, because it is a bug fix or an update to the documentation.
- [x] *develop*, because it introduces a new feature.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
