### PR TITLE
Store an empty node and warn when qstat returns an empty string

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,6 +18,11 @@
             "affiliation": "University of Michigan",
             "name": "Timothy Moore",
             "orcid": "0000-0002-5709-7259"
+        },
+        {
+            "affiliation": "Vanderbilt University",
+            "name": "Matthew  W. Thompson",
+            "orcid": "0000-0002-1460-3983"
         }
     ],
     "creators": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -20,11 +20,6 @@
             "orcid": "0000-0002-5709-7259"
         },
         {
-            "affiliation": "Vanderbilt University",
-            "name": "Matthew  W. Thompson",
-            "orcid": "0000-0002-1460-3983"
-        },
-        {
             "affiliation": "University of Michigan",
             "name": "Rose Cersonsky",
             "orcid": "0000-0003-4515-3441"
@@ -32,6 +27,11 @@
         {
             "affiliation": "University of Michigan",
             "name": "Yuan Zhou"
+        },
+        {
+            "affiliation": "Vanderbilt University",
+            "name": "Matthew  W. Thompson",
+            "orcid": "0000-0002-1460-3983"
         }
     ],
     "creators": [

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ next
 ----
 
 - Add function to automatically print all varying state point parameters in the detailed status view triggered by providing option `-p/--parameters` without arguments (#19, #87).
+- Fix issue with the TORQUE scheduler that occured when there was no job scheduled at all on the system (for any user) (#92, #93).
 
 Version 0.7
 ===========

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -49,7 +49,7 @@ contributors:
     given-names: Timothy
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0002-5709-7259"
--
+  -
     family-names: Cersonsky 
     given-names: Rose
     affiliation: "University of Michigan"

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -49,4 +49,9 @@ contributors:
     given-names: Timothy
     affiliation: "University of Michigan"
     orcid: "https://orcid.org/0000-0002-5709-7259"
+  -
+    family-names: Thompson
+    given-names: "Matthew  W."
+    affiliation: "Vanderbilt University"
+    orcid: "https://orcid.org/0000-0002-1460-3983"
 ...

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -12,6 +12,7 @@ import getpass
 import subprocess
 import tempfile
 import logging
+import warnings
 import xml.etree.ElementTree as ET
 
 from .base import Scheduler
@@ -33,6 +34,12 @@ def _fetch(user=None):
             raise RuntimeError("Torque not available.")
         else:
             raise error
+    if results == "":
+        warnings.warn(
+            "No scheduler jobs, from any user(s), were detected. "
+            "This may be the result of a misconfiguration in the "
+            "environment.", UserWarning)
+        results = "<Data></Data>"
     tree = ET.parse(source=result)
     return tree.getroot()
 

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -34,12 +34,12 @@ def _fetch(user=None):
             raise RuntimeError("Torque not available.")
         else:
             raise error
-    if result == "":
+    if len(result.getbuffer()) == 0:
         warnings.warn(
             "No scheduler jobs, from any user(s), were detected. "
             "This may be the result of a misconfiguration in the "
             "environment.", UserWarning)
-        result = "<Data></Data>"
+        result = io.BytesIO(b"<Data></Data>")
     tree = ET.parse(source=result)
     return tree.getroot()
 

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -12,7 +12,6 @@ import getpass
 import subprocess
 import tempfile
 import logging
-import warnings
 import xml.etree.ElementTree as ET
 
 from .base import Scheduler

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -34,12 +34,12 @@ def _fetch(user=None):
             raise RuntimeError("Torque not available.")
         else:
             raise error
-    if results == "":
+    if result == "":
         warnings.warn(
             "No scheduler jobs, from any user(s), were detected. "
             "This may be the result of a misconfiguration in the "
             "environment.", UserWarning)
-        results = "<Data></Data>"
+        result = "<Data></Data>"
     tree = ET.parse(source=result)
     return tree.getroot()
 

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -29,19 +29,23 @@ def _fetch(user=None):
     cmd = "qstat -fx -u {user}".format(user=user)
     try:
         result = io.BytesIO(subprocess.check_output(cmd.split()))
+        tree = ET.parse(source=result)
+        return tree.getroot()
+    except ET.ParseError as error:
+        if str(error) == 'no element found: line 1, column 0':
+            logger.warn(
+                "No scheduler jobs, from any user(s), were detected. "
+                "This may be the result of a misconfiguration in the "
+                "environment.")
+            # Return empty, but well-formed result:
+            return ET.parse(source=io.BytesIO(b"<Data></Data>"))
+        else:
+            raise
     except (IOError, OSError) as error:
         if error.errno == errno.ENOENT:
             raise RuntimeError("Torque not available.")
         else:
             raise error
-    if len(result.getbuffer()) == 0:
-        warnings.warn(
-            "No scheduler jobs, from any user(s), were detected. "
-            "This may be the result of a misconfiguration in the "
-            "environment.", UserWarning)
-        result = io.BytesIO(b"<Data></Data>")
-    tree = ET.parse(source=result)
-    return tree.getroot()
 
 
 class TorqueJob(ClusterJob):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

In at least one rare case, the call to `qstat` can return an empty string (`""`) instead of an empty node (`<Data></Data>`) which currently leads to a parser error. This attempts to catch that error and handle it gracefully.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Attempts to fix the behavior reported in detail in #92. It's not clear to me how this sort of direct interaction with a scheduler is handled by tests (`grep -R squeue tests/` gave me nothing) so I have not added supporting tests.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [x] *master*, because it is a bug fix or an update to the documentation. (really just because I branch from `master` out of habit)
- [ ] *develop*, because it introduces a new feature.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
