### PR TITLE
Feature/optimize status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,7 @@ next
 Changed
 ++++++
 
-- The performance of status updates has been improved by a factor of up to 1000 for large data spaces by only pulling from the status cache once rather than once per operation (#94).
+- The performance of status updates has been significantly improved (up to a factor of 1,000 for large data spaces) by applying a more efficient caching strategy (#94).
 - Add clear environment notification when submitting job scripts.
 
 Version 0.7

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ next
 Changed
 ++++++
 
-- Status updates only pull from the cache once rather than once per operation.
+- The performance of status updates has been improved by a factor of up to 1000 for large data spaces by only pulling from the status cache once rather than once per operation.
 
 
 Version 0.7

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,15 @@ Changes
 
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 
+next
+----
+
+Changed
+++++++
+
+- Status updates only pull from the cache once rather than once per operation.
+
+
 Version 0.7
 ===========
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,7 @@ next
 Changed
 ++++++
 
-- The performance of status updates has been improved by a factor of up to 1000 for large data spaces by only pulling from the status cache once rather than once per operation.
+- The performance of status updates has been improved by a factor of up to 1000 for large data spaces by only pulling from the status cache once rather than once per operation (#94).
 - Add clear environment notification when submitting job scripts.
 
 Version 0.7

--- a/flow/project.py
+++ b/flow/project.py
@@ -943,7 +943,12 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
                     err.flush()
                 yield _
 
-        cached_status = self.document.get('_status', dict())._as_dict()
+        cached_status = self.document.get('_status', dict())
+        # Convert JSONDict to a dictionary if needed
+        try:
+            cached_status = cached_status._as_dict()
+        except AttributeError:
+            pass
         _get_job_status = functools.partial(self.get_job_status,
                                             ignore_errors=ignore_errors,
                                             cached_status=cached_status)

--- a/flow/project.py
+++ b/flow/project.py
@@ -826,16 +826,8 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
                 expanded = JobOperation.expand_id(name)
                 yield expanded['job_id'], expanded['operation-name'], sjob
 
-    def _get_operations_status(self, job, cached_status=None):
+    def _get_operations_status(self, job, cached_status):
         "Return a dict with information about job-operations for this job."
-        if cached_status is None:
-            cached_status = self.document.get('_status', dict())
-            # Convert JSONDict to a dictionary if needed
-            try:
-                cached_status = cached_status._as_dict()
-            except AttributeError:
-                pass
-
         for job_op in self._job_operations([job], False):
             flow_op = self.operations[job_op.name]
             completed = flow_op.complete(job)
@@ -852,6 +844,11 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
         result = dict()
         result['job_id'] = str(job)
         try:
+            if cached_status is None:
+                try:
+                    cached_status = self.document['_status']._as_dict()
+                except KeyError:
+                    cached_status = dict()
             result['operations'] = OrderedDict(self._get_operations_status(job, cached_status))
             result['_operations_error'] = None
         except Exception as error:
@@ -943,12 +940,10 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
                     err.flush()
                 yield _
 
-        cached_status = self.document.get('_status', dict())
-        # Convert JSONDict to a dictionary if needed
         try:
-            cached_status = cached_status._as_dict()
-        except AttributeError:
-            pass
+            cached_status = self.document['_status']._as_dict()
+        except KeyError:
+            cached_status = dict()
         _get_job_status = functools.partial(self.get_job_status,
                                             ignore_errors=ignore_errors,
                                             cached_status=cached_status)

--- a/flow/project.py
+++ b/flow/project.py
@@ -829,7 +829,13 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
     def _get_operations_status(self, job, cached_status=None):
         "Return a dict with information about job-operations for this job."
         if cached_status is None:
-            cached_status = self.document.get('_status', dict())._as_dict()
+            cached_status = self.document.get('_status', dict())
+            # Convert JSONDict to a dictionary if needed
+            try:
+                cached_status = cached_status._as_dict()
+            except AttributeError:
+                pass
+
         for job_op in self._job_operations([job], False):
             flow_op = self.operations[job_op.name]
             completed = flow_op.complete(job)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -146,6 +146,7 @@ class BaseProjectTest(unittest.TestCase):
         return project
 
 
+@unittest.skipIf(six.PY2, 'Only check performance on Python 3')
 class ProjectStatusTest(BaseProjectTest):
 
     class Project(FlowProject):
@@ -171,7 +172,6 @@ class ProjectStatusTest(BaseProjectTest):
         project = self.mock_project()
 
         MockScheduler.reset()
-        project.update_cache()
 
         time = timeit.timeit(
             lambda: project._fetch_status(project, io.StringIO(),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -147,7 +147,7 @@ class BaseProjectTest(unittest.TestCase):
 
 
 @unittest.skipIf(six.PY2, 'Only check performance on Python 3')
-class ProjectStatusTest(BaseProjectTest):
+class ProjectStatusPerformanceTest(BaseProjectTest):
 
     class Project(FlowProject):
         pass

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -146,6 +146,41 @@ class BaseProjectTest(unittest.TestCase):
         return project
 
 
+class ProjectStatusTest(BaseProjectTest):
+
+    class Project(FlowProject):
+        pass
+
+    @Project.operation
+    @Project.post.isfile('DOES_NOT_EXIST')
+    def foo(job):
+        pass
+
+    project_class = Project
+
+    def mock_project(self):
+        project = self.project_class.get_project(root=self._tmp_dir.name)
+        for i in range(1000):
+            project.open_job(dict(i=i)).init()
+        return project
+
+    def test_status_performance(self):
+        '''Ensure that status updates take less than 1 second for a data space of 1000 jobs'''
+        import timeit
+
+        project = self.mock_project()
+
+        MockScheduler.reset()
+        project.update_cache()
+
+        time = timeit.timeit(
+            lambda: project._fetch_status(project, io.StringIO(),
+                ignore_errors=False, no_parallelize=False), number=10)
+
+        self.assertTrue(time < 10)
+        MockScheduler.reset()
+
+
 class ProjectClassTest(BaseProjectTest):
 
     def test_operation_definition(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR accelerates the status update by loading the cached status information only once rather than once per job. Additionally, the status data is immediately converted to a dictionary to avoid expensive calls to the various `_SyncedDict` functions that maintain the integrity of the underlying file. This conversion should be safe since this part of the status fetching is a read-only operation; the status information is written by the `_fetch_scheduler_status` method, but this change only affects the downstream `get_job_status` function calls.

There is one catch: because I'm passing a large dictionary as an argument to the `get_job_status` function there is additional overhead associated with serializing the data for parallelization. In fact, updating in parallel is actually slower than serial updates with the new implementation. As a result, the performance improvement of the new method is far more pronounced in serial than in parallel. There is probably a data size where the old method outperforms the new one if you benchmark parallel status updates only; I'd expect that to be about 50000 jobs based on the set of tests I've run so far. However, the new version running in serial might still be the fastest. I'm going to run a test on 1e5 data points once, just to be sure.

As a benchmark, I constructed test data spaces of 1000 and 10000 jobs and defined a FlowProject with a single operation with a simple file existence post-condition. I've attached the results in a text file, but the summary is that when status updates are performed in serial (passing the `--no-parallelize` option) the performance is now improved by a factor of almost 100. When parallelism is allowed, this advantage shrinks considerably but is still at least a factor of 5.


## Motivation and Context
For large data spaces (>1000 jobs) the current status update is far too slow. In particular, the collection of individual job status information takes extremely long because each individual job is accessing the `_status` key in the project document, which is an extremely large file for such large data spaces. 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [ ] *master*, because it is a bug fix or an update to the documentation.
- [x] *develop*, because it introduces a new feature.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
