### PR TITLE
Initial exception handling of scheduler errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ next
 ----
 
 - Add full launcher support for job submission on XSEDE Stampede2 for large parallel single processor jobs (#85, #91).
+- Show submission error messages in combination with a TORQUE scheduler (#103, #104).
 
 Version 0.7
 ===========

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -72,4 +72,9 @@ contributors:
     family-names: Melle
     given-names: Yannah
     affiliation: "University of Michigan"
+  -
+    family-names: Justin
+    given-names: Gilmer
+    affiliation: "Vanderbilt University"
+    orcid: "https://orcid.org/0000-0002-6915-5591"
 ...

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -16,6 +16,7 @@ import xml.etree.ElementTree as ET
 
 from .base import Scheduler
 from .base import ClusterJob, JobStatus
+from ..errors import SubmitError
 
 
 logger = logging.getLogger(__name__)
@@ -146,9 +147,12 @@ class TorqueScheduler(Scheduler):
             with tempfile.NamedTemporaryFile() as tmp_submit_script:
                 tmp_submit_script.write(str(script).encode('utf-8'))
                 tmp_submit_script.flush()
-                output = subprocess.check_output(
-                    submit_cmd + [tmp_submit_script.name])
-            jobsid = output.decode('utf-8').strip()
+                try:
+                    output = subprocess.check_output(
+                        submit_cmd + [tmp_submit_script.name])
+                    jobsid = output.decode('utf-8').strip()
+                except subprocess.CalledProcessError as e:
+                    raise SubmitError("qsub error: {}".format(e.output()))
             return jobsid
 
     @classmethod


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
In `torque.py`, when the call is made using the `subprocess` module,
if the scheduler returns an error that message is not passed on to the
user. The error code is, but usually that is not enough to debug what
could be the cause of that issue.

This PR attempts to catch that exception and provide it to the user.

## Motivation and Context
Debugging scheduler submissions can be difficult when only provided the error code.
This change will provide the users the full output from the `subprocess` module
as a way to more easily determine what in their script was incorrect.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is related to issue #103 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

This pull request is based on
- [x] *master*, because it is a bug fix or an update to the documentation.
- [ ] *develop*, because it introduces a new feature.

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
