### PR TITLE
Make progressbar on a per-job basis

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@ next
 
 - Add full launcher support for job submission on XSEDE Stampede2 for large parallel single processor jobs (#85, #91).
 - Show submission error messages in combination with a TORQUE scheduler (#103, #104).
-- Fix "Fetching operation status" progressbar to scale up to number of jobs (which is a known quantity) instead of job-operations (which are not known a priori) (#108).
+- Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 
 Version 0.7
 ===========

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ next
 
 - Add full launcher support for job submission on XSEDE Stampede2 for large parallel single processor jobs (#85, #91).
 - Show submission error messages in combination with a TORQUE scheduler (#103, #104).
+- Fix "Fetching operation status" progressbar to scale up to number of jobs (which is a known quantity) instead of job-operations (which are not known a priori) (#108).
 
 Version 0.7
 ===========

--- a/flow/project.py
+++ b/flow/project.py
@@ -914,10 +914,11 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
             scheduler_info = {sjob.name(): sjob.status() for sjob in self.scheduler_jobs(scheduler)}
             status = dict()
             print(self._tr("Query scheduler..."), file=file)
-            for op in tqdm(self._job_operations(jobs=jobs, only_eligible=False),
-                           desc="Fetching operation status",
-                           total=len(jobs), file=file):
-                status[op.get_id()] = int(scheduler_info.get(op.get_id(), JobStatus.unknown))
+            for job in tqdm(jobs,
+                            desc="Fetching operation status",
+                            total=len(jobs), file=file):
+                for op in self._job_operations(jobs=[job], only_eligible=False):
+                    status[op.get_id()] = int(scheduler_info.get(op.get_id(), JobStatus.unknown))
             self.document._status.update(status)
         except NoSchedulerError:
             logger.debug("No scheduler available.")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This pull request fixes the progress bar drawn when fetching status information.

## Description
As of the last release of flow, I added an additional progressbar to the scheduler status fetching because that step can be slow when there are large numbers of operations. However, I had set the total on that progressbar to be the number of jobs, not the number of job-operations, so the available progressbar was exhausted before the iterations completed. This PR fixes that problem by counting up to the number of jobs.  @justinGilmer let me know if this fixes your problem.

There is a catch to this; because the iterable is a generator that filters out ineligible operations, we don't know the total number *a priori*. To fix this issue, I replaced the original logic with two nested loops, one over jobs and one over the operations for each job. I'm not sure what a better solution to this would be, but I'm open to suggestions.

Related, the history for the last set of changes is a little confusing. I see two different commit entries for the PR merge that added this progressbar, e590d70de073bc4e466baf03ab749c60f3c0c02a and 564417c0303c4418adea73fc945e1e260367b899. In 564417c0, the relevant progressbar line uses `next_operations`, which is what I recall putting there and what is shown in Pull Request #94, but e590d70d matches the current master, which directly calls `_job_operations(jobs=jobs, only_eligible=False)`. I'm not sure how or why this change was made, but I don't think it's necessary; we shouldn't need to update the scheduler status for ineligible jobs. Any idea what could have caused this? I'd like to fix, but since I don't recall making this change perhaps someone else had a reason for doing so.

## Motivation and Context
Closes #108

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
