### PR TITLE
Fix default np directive when callable directives are provided

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,11 @@ next
 - Show submission error messages in combination with a TORQUE scheduler (#103, #104).
 - Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 
+Fixes
++++++
+
+- Both the ``nranks`` and ``omp_num_threads`` directives properly support callables.
+
 Version 0.7
 ===========
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -244,13 +244,17 @@ class JobOperation(object):
         keys_set_by_user = set(directives.keys())
 
         nranks = directives.get('nranks', 1)
-        omp_num_threads = directives.get('omp_num_threads', 1)
+        nthreads = directives.get('omp_num_threads', 1)
 
-        if callable(nranks) or callable(omp_num_threads):
-            np_callable = lambda job: (nranks(job) if callable(nranks) else nranks) * (
-                    omp_num_threads(job) if callable(omp_num_threads) else omp_num_threads)
+        if callable(nranks) or callable(nthreads):
+            def np_callable(job):
+                nr = nranks(job) if callable(nranks) else nranks
+                nt = nthreads(job) if callable(nthreads) else nthreads
+                return nr*nt
+
+            directives.setdefault('np', np_callable)
         else:
-            directives.setdefault('np', nranks*omp_num_threads )
+            directives.setdefault('np', nranks*nthreads)
 
         directives.setdefault('ngpu', 0)
         directives.setdefault('nranks', 0)

--- a/flow/project.py
+++ b/flow/project.py
@@ -245,19 +245,12 @@ class JobOperation(object):
 
         nranks = directives.get('nranks', 1)
         omp_num_threads = directives.get('omp_num_threads', 1)
-        if callable(nranks):
-            if callable(omp_num_threads):
-                directives.setdefault(
-                    'np', lambda job: nranks(job)*omp_num_threads(job) )
-            else:
-                directives.setdefault(
-                    'np', lambda job: nranks(job)*omp_num_threads )
-        elif callable(omp_num_threads):
-            directives.setdefault(
-                'np', lambda job: nranks*omp_num_threads(job) )
+
+        if callable(nranks) or callable(omp_num_threads):
+            np_callable = lambda job: (nranks(job) if callable(nranks) else nranks) * (
+                    omp_num_threads(job) if callable(omp_num_threads) else omp_num_threads)
         else:
-            directives.setdefault(
-                'np', lambda job: nranks*omp_num_threads )
+            directives.setdefault('np', nranks*omp_num_threads )
 
         directives.setdefault('ngpu', 0)
         directives.setdefault('nranks', 0)

--- a/flow/project.py
+++ b/flow/project.py
@@ -243,8 +243,22 @@ class JobOperation(object):
         # script engine later.
         keys_set_by_user = set(directives.keys())
 
-        directives.setdefault(
-            'np', directives.get('nranks', 1) * directives.get('omp_num_threads', 1))
+        nranks = directives.get('nranks', 1)
+        omp_num_threads = directives.get('omp_num_threads', 1)
+        if callable(nranks):
+            if callable(omp_num_threads):
+                directives.setdefault(
+                    'np', lambda job: nranks(job)*omp_num_threads(job) )
+            else:
+                directives.setdefault(
+                    'np', lambda job: nranks(job)*omp_num_threads )
+        elif callable(omp_num_threads):
+            directives.setdefault(
+                'np', lambda job: nranks*omp_num_threads(job) )
+        else:
+            directives.setdefault(
+                'np', lambda job: nranks*omp_num_threads )
+
         directives.setdefault('ngpu', 0)
         directives.setdefault('nranks', 0)
         directives.setdefault('omp_num_threads', 0)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -434,14 +434,14 @@ class ProjectClassTest(BaseProjectTest):
             job.doc.nranks = i+1
             next_op = project.next_operation(job)
             self.assertEqual(next_op.directives['np'], next_op.directives['nranks'])
-            del job.doc.nranks
+            del job.doc['nranks']
 
         # test only setting omp_num_threads
         for i, job in enumerate(project):
             job.doc.omp_num_threads = i+1
             next_op = project.next_operation(job)
             self.assertEqual(next_op.directives['np'], next_op.directives['omp_num_threads'])
-            del job.doc.omp_num_threads
+            del job.doc['omp_num_threads']
 
         # test setting both nranks and omp_num_threads
         for i, job in enumerate(project):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -418,7 +418,7 @@ class ProjectClassTest(BaseProjectTest):
 
         @A.operation
         @directives(nranks=lambda job: job.doc.get('nranks', 1))
-        @directives(omp_num_threads=lambda job:job.doc.get('omp_num_threads', 1))
+        @directives(omp_num_threads=lambda job: job.doc.get('omp_num_threads', 1))
         def a(job):
             return 'hello!'
 
@@ -450,6 +450,7 @@ class ProjectClassTest(BaseProjectTest):
             next_op = project.next_operation(job)
             expected_np = (i + 1) * (i % 3 + 1)
             self.assertEqual(next_op.directives['np'], expected_np)
+
 
 class ProjectTest(BaseProjectTest):
     project_class = TestProject


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
I fixed a bug that occurs when the `nranks` or `omp_num_threads` directives are specified using callables. I'm open to suggestions on how to make this less verbose. One alternative is:

```bash
if callable(nranks) or callable(omp_num_threads):
    np_callable = lambda job: (nranks(job) if callable(nranks) else nranks) * (omp_num_threads(job) if callable(omp_num_threads) else omp_num_threads)
    directives.setdefault('np', np_callable )
else:
    directives.setdefault('np', nranks*omp_num_threads )
```

but I find that pretty unappealing because it makes the lambda function complicated enough that I don't find it more readable. If others strongly prefer it then we could do that, though.

## Motivation and Context
The `np` directive is set based on the `nranks` and `omp_num_threads` directives. However, if either of these are callables, the current default setting for `np` will not work; we need to define it as a callable as well. Without this fix, these submissions fail.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [x] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
