### PR TITLE
Enable copy_from and after conditions with multiple arguments.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ next
 - Show submission error messages in combination with a TORQUE scheduler (#103, #104).
 - Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 - Rewrite print status function using Jinja2 templates.
+- Allow the provision of multiple operation-functions to the `pre.after` condition (#120).
 
 Version 0.7
 ===========

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,7 @@ next
 - Show submission error messages in combination with a TORQUE scheduler (#103, #104).
 - Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 - Rewrite print status function using Jinja2 templates.
-- Allow the provision of multiple operation-functions to the `pre.after` condition (#120).
+- Allow the provision of multiple operation-functions to the ``pre.after`` and ``*.copy_from`` conditions (#120).
 
 Version 0.7
 ===========

--- a/flow/project.py
+++ b/flow/project.py
@@ -139,19 +139,21 @@ class _pre(_condition):
         return func
 
     @classmethod
-    def copy_from(cls, other_func):
+    def copy_from(cls, *other_funcs):
         "True if and only if all pre conditions of other function are met."
         def metacondition(job):
-            pre_conditions = getattr(other_func, '_flow_pre', list())
-            return all(c(job) for c in pre_conditions)
+            return all(c(job)
+                       for other_func in other_funcs
+                       for c in getattr(other_func, '_flow_pre', list()))
         return cls(metacondition)
 
     @classmethod
-    def after(cls, other_func):
+    def after(cls, *other_funcs):
         "True if and only if all post conditions of other function are met."
         def metacondition(job):
-            post_conditions = getattr(other_func, '_flow_post', list())
-            return all(c(job) for c in post_conditions)
+            return all(c(job)
+                       for other_func in other_funcs
+                       for c in getattr(other_func, '_flow_post', list()))
         return cls(metacondition)
 
 
@@ -167,11 +169,12 @@ class _post(_condition):
         return func
 
     @classmethod
-    def copy_from(cls, other_func):
+    def copy_from(cls, *other_funcs):
         "True if and only if all post conditions of other function are met."
         def metacondition(job):
-            post_conditions = getattr(other_func, '_flow_post', list())
-            return all(c(job) for c in post_conditions)
+            return all(c(job)
+                       for other_func in other_funcs
+                       for c in getattr(other_func, '_flow_post', list()))
         return cls(metacondition)
 
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -140,7 +140,7 @@ class _pre(_condition):
 
     @classmethod
     def copy_from(cls, *other_funcs):
-        "True if and only if all pre conditions of other function are met."
+        "True if and only if all pre conditions of other function(s) are met."
         def metacondition(job):
             return all(c(job)
                        for other_func in other_funcs
@@ -149,7 +149,7 @@ class _pre(_condition):
 
     @classmethod
     def after(cls, *other_funcs):
-        "True if and only if all post conditions of other function are met."
+        "True if and only if all post conditions of other function(s) are met."
         def metacondition(job):
             return all(c(job)
                        for other_func in other_funcs
@@ -170,7 +170,7 @@ class _post(_condition):
 
     @classmethod
     def copy_from(cls, *other_funcs):
-        "True if and only if all post conditions of other function are met."
+        "True if and only if all post conditions of other function(s) are met."
         def metacondition(job):
             return all(c(job)
                        for other_func in other_funcs

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -474,8 +474,7 @@ class ProjectClassTest(BaseProjectTest):
             job.doc.c = True
 
         @A.operation
-        @A.pre.copy_from(op1)  # should be empty
-        @A.pre.copy_from(op3)
+        @A.pre.copy_from(op1, op3)
         @A.post.true('d')
         def op4(job):
             job.doc.d = True


### PR DESCRIPTION
## Description

Enable the provision of multiple operation functions as argument to `pre.after()` and `pre/post.copy_from()` 

## Motivation and Context

When generating operation functions programmatically, it is much more convenient to store those in a list and then we can use those lists as argument to the condition functions. Otherwise we cannot use the decorator syntax.

### Minimal example:
```python
def setup_foo(i):

    @Project.operation(f'foo-{i}')
    @Project.post.true(f'{foo_{i}')
    def foo(job):
        print(f"{i}th foo!")
        job.doc[f'foo_{i}'] = True

    return foo

foos = [setup_foo(i) for i in range(3)]

@Project.operation
@Project.pre.after(*foos)
def bar(job):
    print('all foos ran!')
```

**Without this feature** we would need to awkwardly call `Project.pre.after` as a function manually:
```python
for foo in foos:
    Project.pre.after(foo)(bar)
```

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
