### PR TITLE
Make environments opt-out

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,11 @@ next
 - Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 - Rewrite print status function using Jinja2 templates.
 
+Changed
++++++++
+
+- Packaged environments are now available by default and can be disabled by setting the config value IMPORT_ENVIRONMENTS.
+
 Version 0.7
 ===========
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@ next
 Changed
 +++++++
 
-- Packaged environments are now available by default and can be disabled by setting the config value IMPORT_ENVIRONMENTS.
+- Packaged environments are now available by default. Set "import_packaged_environments = off" within the signac configuration "[flow]" section to revert to previous behavior.
 
 Version 0.7
 ===========

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -25,15 +25,9 @@ from .template import init
 from .util.misc import redirect_log
 from .operations import with_job
 
-# Enable flow environments on an opt-out basis. Users must set the relevant
-# configuration variable to avoid environment being imported. This may be done
-# on either a global or a local configuration level. The order of precedence is
-# local up to global.
+# Import packaged environments unless disabled in config:
 from .util.config import get_config_value
-
-
-auto_import_environments = get_config_value('auto_import_environments', default=True)
-if auto_import_environments:
+if get_config_value('import_packaged_environments', default=True):
     from . import environments  # noqa:F401
 
 

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -29,7 +29,6 @@ from .operations import with_job
 # configuration variable to avoid environment being imported. This may be done
 # on either a global or a local configuration level. The order of precedence is
 # local up to global.
-from signac.common import config as _config
 from signac import get_project as _get_project
 
 # Work up in the correct order

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -31,13 +31,9 @@ from .operations import with_job
 # local up to global.
 from .util.config import get_config_value
 
-# Work up in the correct order
-try:
-    flag = get_config_value('IMPORT_ENVIRONMENTS')
-except LookupError:
-    flag = None
 
-if flag is None or flag == "True":
+auto_import_environments = get_config_value('auto_import_environments', default=True)
+if auto_import_environments:
     from . import environments  # noqa:F401
 
 

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -32,7 +32,10 @@ from .operations import with_job
 from signac import get_project as _get_project
 
 # Work up in the correct order
-flag = _get_project().config['flow'].get('IMPORT_ENVIRONMENTS')
+try:
+    flag = _get_project().config['flow'].get('IMPORT_ENVIRONMENTS')
+except LookupError:
+    flag = None
 
 if flag is None or flag == "True":
     from . import environments  # noqa:F401

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -29,11 +29,11 @@ from .operations import with_job
 # configuration variable to avoid environment being imported. This may be done
 # on either a global or a local configuration level. The order of precedence is
 # local up to global.
-from signac import get_project as _get_project
+from .util.config import get_config_value
 
 # Work up in the correct order
 try:
-    flag = _get_project().config['flow'].get('IMPORT_ENVIRONMENTS')
+    flag = get_config_value('IMPORT_ENVIRONMENTS')
 except LookupError:
     flag = None
 

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -25,6 +25,20 @@ from .template import init
 from .util.misc import redirect_log
 from .operations import with_job
 
+# Enable flow environments on an opt-out basis. Users must set the relevant
+# configuration variable to avoid environment being imported. This may be done
+# on either a global or a local configuration level. The order of precedence is
+# local up to global.
+from signac.common import config as _config
+from signac import get_project as _get_project
+
+# Work up in the correct order
+flag = _get_project().config['flow'].get('IMPORT_ENVIRONMENTS')
+
+if flag is None or flag == "True":
+    from . import environments  # noqa:F401
+
+
 __version__ = '0.7.1'
 
 __all__ = [

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -8,6 +8,13 @@ from signac.common import config
 from ..errors import ConfigKeyError
 
 
+# Monkeypatch the signac config spec to include flow-specific fields.
+config.cfg += """
+[flow]
+auto_import_environments = boolean()
+"""
+
+
 class _GetConfigValueNoneType(object):
     pass
 

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -11,7 +11,7 @@ from ..errors import ConfigKeyError
 # Monkeypatch the signac config spec to include flow-specific fields.
 config.cfg += """
 [flow]
-auto_import_environments = boolean()
+import_packaged_environments = boolean()
 """
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Environments are now imported by default. This can be avoided by setting a signac configuration variable.

## Motivation and Context
In general, users expect environments to be available and are surprised when they're not.
This resolves #16. 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [x] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
