### PR TITLE
fixing PBS pmem typo

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ next
 - Fix issue that caused the "Fetching operation status" progressbar to be inaccurate (#108).
 - Rewrite print status function using Jinja2 templates.
 - Add option to specify the operation execution order (#121).
+- Fix erroneous line in the torque submission template (#126).
 
 Fixes
 +++++

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -82,4 +82,9 @@ contributors:
     given-names: Gilmer
     affiliation: "Vanderbilt University"
     orcid: "https://orcid.org/0000-0002-6915-5591"
+  -
+    family-names: Travitz
+    given-names: Alyssa
+    affiliation: "University of Michigan"
+    orcid: "https://orcid.org/0000-0001-5953-8807"
 ...

--- a/flow/templates/torque.sh
+++ b/flow/templates/torque.sh
@@ -8,7 +8,7 @@
 #PBS -V
 {% endif %}
 {% if memory %}
-#PBS -l pmem={{ memory }}g
+#PBS -l pmem={{ memory }}
 {% endif %}
 {% block tasks %}
 {% set threshold = 0 if force else 0.9 %}


### PR DESCRIPTION
Removing extraneous "g" on pmem arguments.

<!-- Provide a general summary of your changes in the Title above -->

## Description
Removing extraneous "g" on pmem arguments. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
pmem can be assigned in any units of memory, instead of gigabytes only

<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
