### PR TITLE
Implement the "fork" directive.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@ next
 - Fix erroneous line in the torque submission template (#126).
 - Add a testing module to easily initialize a test project (#130).
 - Add feature for integrated profiling of status updates to aid with the optimization of the FlowProject imlementation (#107, #110).
-- Add 'fork' directive to enforce the execution of operations within a subprocess.
+- Add ``@fork()`` decorator to enforce the execution of operations within a subprocess.
 
 Fixes
 +++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ next
 - Allow the provision of multiple operation-functions to the ``pre.after`` and ``*.copy_from`` conditions (#120).
 - Add option to specify the operation execution order (#121).
 - Fix erroneous line in the torque submission template (#126).
+- Add 'fork' directive to enforce the execution of operations within a subprocess.
 
 Fixes
 +++++

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -19,6 +19,7 @@ from .project import label
 from .project import classlabel
 from .project import staticlabel
 from .operations import cmd
+from .operations import fork
 from .operations import directives
 from .operations import run
 from .environment import get_environment
@@ -44,6 +45,7 @@ __all__ = [
     'classlabel',
     'staticlabel',
     'cmd',
+    'fork',
     'directives',
     'run',
     'init',

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -100,17 +100,40 @@ def with_job(func):
     return decorated
 
 
-def fork(func):
+def fork(condition=None):
     """Specifies that ``func`` must be executed within a forked process.
 
     Functions that require their own process and should not be executed within the
-    same process as the interpreter should be decorated with `@fork`.
-
+    same process as the interpreter should be decorated with `@fork()`.
     This is useful for example for parallelized operations, such as functions
     that use `multiprocessing.Pool`.
+
+    You can specify an optional condition, which must be a function of job, to fork
+    only under specific circumstances. For example:
+
+    .. code-block:: python
+
+        @Project.operation
+        @fork()
+        def op_always_forks(job):
+            pass
+
+        def fork_condition(job):
+            return job.doc.fork is True
+
+        @Project.operation
+        @fork(fork_condition)
+        def op_forks_conditionally(job):
+            pass
     """
-    setattr(func, '_flow_fork', True)
-    return func
+    if condition is None:
+        condition = True
+
+    def _decorator(func):
+        setattr(func, '_flow_fork', condition)
+        return func
+
+    return _decorator
 
 
 class directives(object):

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -18,7 +18,7 @@ from signac import get_project
 from signac.common import six
 
 from .util.tqdm import tqdm
-from .util.execution import fork
+from .util.execution import fork as _fork
 
 
 logger = logging.getLogger(__name__)
@@ -98,6 +98,19 @@ def with_job(func):
 
     setattr(decorated, '_flow_with_job', True)
     return decorated
+
+
+def fork(func):
+    """Specifies that ``func`` must be executed within a forked process.
+
+    Functions that require their own process and should not be executed within the
+    same process as the interpreter should be decorated with `@fork`.
+
+    This is useful for example for parallelized operations, such as functions
+    that use `multiprocessing.Pool`.
+    """
+    setattr(func, '_flow_fork', True)
+    return func
 
 
 class directives(object):
@@ -240,7 +253,7 @@ def run(parser=None):
 
         def operation(job):
             cmd = operation_func(job).format(job=job)
-            fork(cmd=cmd, timeout=args.timeout)
+            _fork(cmd=cmd, timeout=args.timeout)
     else:
         operation = operation_func
 
@@ -268,4 +281,4 @@ def run(parser=None):
                 result.next(args.timeout)
 
 
-__all__ = ['cmd', 'directives', 'run']
+__all__ = ['cmd', 'fork', 'directives', 'run']

--- a/flow/project.py
+++ b/flow/project.py
@@ -1447,8 +1447,10 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
         logger.info("Execute operation '{}'...".format(operation))
 
         # Execute without forking if possible...
-        if timeout is None and operation.name in self._operation_functions and \
-                operation.directives.get('executable', sys.executable) == sys.executable:
+        if not operation.directives.get('fork') \
+            and timeout is None \
+            and operation.name in self._operation_functions \
+            and operation.directives.get('executable', sys.executable) == sys.executable:
             logger.debug("Able to optimize execution of operation '{}'.".format(operation))
             self._operation_functions[operation.name](operation.job)
         else:   # need to fork

--- a/flow/project.py
+++ b/flow/project.py
@@ -1484,7 +1484,7 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
                 if pretend:
                     print(operation.cmd)
                 else:
-                    self._fork(operation, timeout)
+                    self._execute_operation(operation, timeout)
         else:
             logger.debug("Parallelized execution of {} operation(s).".format(len(operations)))
             with contextlib.closing(Pool(processes=cpu_count() if np < 0 else np)) as pool:
@@ -1542,28 +1542,36 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
         except Exception as error:  # Masking all errors since they must be pickling related.
             raise self._PickleError(error)
 
-        results = [pool.apply_async(_fork_with_serialization, task) for task in s_tasks]
+        results = [pool.apply_async(_execute_serialized_operation, task) for task in s_tasks]
 
         for result in tqdm(results) if progress else results:
             result.get(timeout=timeout)
 
-    def _fork(self, operation, timeout=None):
+    def _execute_operation(self, operation, timeout=None):
         logger.info("Execute operation '{}'...".format(operation))
 
-        # Execute without forking if possible...
-        if not (operation.fork and (operation.fork is True or operation.fork(operation.job))) \
-                and timeout is None \
-                and operation.name in self._operation_functions \
-                and operation.directives.get('executable', sys.executable) == sys.executable:
-            logger.debug(
-                "Executing operation '{}' with current interpreter "
-                "process ({}).".format(operation, os.getpid()))
-            self._operation_functions[operation.name](operation.job)
-        else:   # need to fork
+        # Check if we need to fork for operation execution...
+        if (
+            # The @fork decorator was applied:
+            (operation.fork and (operation.fork is True or operation.fork(operation.job)))
+            # Separate process needed to cancel with timeout:
+            or timeout is not None
+            # The operation function is not registered with the class:
+            or operation.name not in self._operation_functions
+            # The specified executable is not the same as the interpreter instance:
+            or operation.directives.get('executable', sys.executable) != sys.executable
+        ):
+            # ... need to fork:
             logger.debug(
                 "Forking to execute operation '{}' with "
                 "cmd '{}'.".format(operation, operation.cmd))
             fork(cmd=operation.cmd, timeout=timeout)
+        else:
+            # ... executing operation in interpreter process as function:
+            logger.debug(
+                "Executing operation '{}' with current interpreter "
+                "process ({}).".format(operation, os.getpid()))
+            self._operation_functions[operation.name](operation.job)
 
     def run(self, jobs=None, names=None, pretend=False, np=None, timeout=None, num=None,
             num_passes=1, progress=False, order=None):
@@ -2880,10 +2888,10 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
             _exit_or_raise()
 
 
-def _fork_with_serialization(loads, project, operation):
-    """Invoke the _fork() method on a serialized project instance."""
+def _execute_serialized_operation(loads, project, operation):
+    """Invoke the _execute_operation() method on a serialized project instance."""
     project = loads(project)
-    project._fork(project._loads_op(operation))
+    project._execute_operation(project._loads_op(operation))
 
 
 ###

--- a/flow/project.py
+++ b/flow/project.py
@@ -1448,9 +1448,9 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
 
         # Execute without forking if possible...
         if not operation.directives.get('fork') \
-            and timeout is None \
-            and operation.name in self._operation_functions \
-            and operation.directives.get('executable', sys.executable) == sys.executable:
+                and timeout is None \
+                and operation.name in self._operation_functions \
+                and operation.directives.get('executable', sys.executable) == sys.executable:
             logger.debug("Able to optimize execution of operation '{}'.".format(operation))
             self._operation_functions[operation.name](operation.job)
         else:   # need to fork

--- a/flow/project.py
+++ b/flow/project.py
@@ -1519,11 +1519,11 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
 
     @staticmethod
     def _dumps_op(op):
-        return (op.name, op.job._id, op.cmd, op.directives)
+        return (op.name, op.job._id, op.cmd, op.fork, op.directives)
 
     def _loads_op(self, blob):
-        name, job_id, cmd, directives = blob
-        return JobOperation(name, self.open_job(id=job_id), cmd, directives)
+        name, job_id, cmd, fork, directives = blob
+        return JobOperation(name, self.open_job(id=job_id), cmd, fork, directives)
 
     def _run_operations_in_parallel(self, pool, pickle, operations, progress, timeout):
         """Execute operations in parallel.
@@ -1551,7 +1551,7 @@ class FlowProject(six.with_metaclass(_FlowProjectClass,
         logger.info("Execute operation '{}'...".format(operation))
 
         # Execute without forking if possible...
-        if not operation.fork \
+        if not (operation.fork and (operation.fork is True or operation.fork(operation.job))) \
                 and timeout is None \
                 and operation.name in self._operation_functions \
                 and operation.directives.get('executable', sys.executable) == sys.executable:

--- a/tests/define_test_project.py
+++ b/tests/define_test_project.py
@@ -1,3 +1,4 @@
+import os
 import flow
 from flow import FlowProject
 
@@ -38,10 +39,15 @@ def op1(job):
     return 'echo "hello" > {job.ws}/world.txt'
 
 
+def _need_to_fork(job):
+    return job.doc.get('fork')
+
+
 @TestProject.operation
+@flow.fork(_need_to_fork)
 @TestProject.post.true('test')
 def op2(job):
-    job.document.test = True
+    job.document.test = os.getpid()
 
 
 class TestDynamicProject(TestProject):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -705,6 +705,7 @@ class ExecutionProjectTest(BaseProjectTest):
 
     @unittest.skipIf(StrictVersion(signac.__version__) < StrictVersion('0.9.1'),
                      'requires signac >=0.9.1')
+    @unittest.skipIf(six.PY2, 'requires python 3')
     def test_run_fork(self):
         project = self.mock_project()
         output = StringIO()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -703,6 +703,24 @@ class ExecutionProjectTest(BaseProjectTest):
             else:
                 self.assertFalse(job.isfile('world.txt'))
 
+    def test_run_fork(self):
+        project = self.mock_project()
+        output = StringIO()
+        for job in project:
+            job.doc.fork = True
+            break
+
+        with add_cwd_to_environment_pythonpath():
+            with switch_to_directory(project.root_directory()):
+                with redirect_stderr(output):
+                    project.run()
+
+        for job in project:
+            if job.doc.get('fork'):
+                self.assertNotEqual(os.getpid(), job.doc.test)
+            else:
+                self.assertEqual(os.getpid(), job.doc.test)
+
     def test_submit_operations(self):
         MockScheduler.reset()
         project = self.mock_project()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -703,6 +703,8 @@ class ExecutionProjectTest(BaseProjectTest):
             else:
                 self.assertFalse(job.isfile('world.txt'))
 
+    @unittest.skipIf(StrictVersion(signac.__version__) < StrictVersion('0.9.1'),
+                     'requires signac >=0.9.1')
     def test_run_fork(self):
         project = self.mock_project()
         output = StringIO()


### PR DESCRIPTION
## Description

If the "fork" directive is True, operations are always executed within a
subprocess even if they could be called directly.

## Motivation and Context

This is useful whenever certain parallelization schemes must be executed
within a nondaemonic process, e.g., `multiprocessing.Pool`.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
