### PR TITLE
Update tested signac versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,18 +71,22 @@ jobs:
           path: test-reports
           destination: test-reports
 
-  test-3.7-signac-0.9.0:
+  test-3.7-signac-0.9.5:
     <<: *test-template
     environment:
-      SIGNAC_VERSION: "v0.9.0"
-  test-3.7-signac-0.9.4:
-    <<: *test-template
-    environment:
-      SIGNAC_VERSION: "v0.9.4"
+      SIGNAC_VERSION: "v0.9.5"
   test-3.7-signac-1.0.0:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "v1.0.0"
+  test-3.7-signac-1.1.0:
+    <<: *test-template
+    environment:
+      SIGNAC_VERSION: "v1.1.0"
+  test-3.7-signac-1.2.0:
+    <<: *test-template
+    environment:
+      SIGNAC_VERSION: "v1.2.0"
   test-3.6:
     <<: *test-template
     docker:
@@ -99,18 +103,22 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:2.7
-  test-2.7-signac-0.9.0:
+  test-2.7-signac-0.9.5:
     <<: *test-template-27
     environment:
-      SIGNAC_VERSION: "v0.9.0"
-  test-2.7-signac-0.9.4:
-    <<: *test-template-27
-    environment:
-      SIGNAC_VERSION: "v0.9.4"
+      SIGNAC_VERSION: "v0.9.5"
   test-2.7-signac-1.0.0:
     <<: *test-template-27
     environment:
       SIGNAC_VERSION: "v1.0.0"
+  test-2.7-signac-1.1.0:
+    <<: *test-template-27
+    environment:
+      SIGNAC_VERSION: "v1.1.0"
+  test-2.7-signac-1.2.0:
+    <<: *test-template-27
+    environment:
+      SIGNAC_VERSION: "v1.2.0"
 
   test-deploy-pypi:
     docker:
@@ -149,13 +157,16 @@ workflows:
       - test-2.7:
           requires:
             - pre-test-checks
-      - test-2.7-signac-0.9.0:
-          requires:
-            - test-2.7
-      - test-2.7-signac-0.9.4:
+      - test-2.7-signac-0.9.5:
           requires:
             - test-2.7
       - test-2.7-signac-1.0.0:
+          requires:
+            - test-2.7
+      - test-2.7-signac-1.1.0:
+          requires:
+            - test-2.7
+      - test-2.7-signac-1.2.0:
           requires:
             - test-2.7
       - test-3.4:
@@ -170,13 +181,16 @@ workflows:
       - test-3.7:
           requires:
             - pre-test-checks
-      - test-3.7-signac-0.9.0:
-          requires:
-            - test-3.7
-      - test-3.7-signac-0.9.4:
+      - test-3.7-signac-0.9.5:
           requires:
             - test-3.7
       - test-3.7-signac-1.0.0:
+          requires:
+            - test-3.7
+      - test-3.7-signac-1.1.0:
+          requires:
+            - test-3.7
+      - test-3.7-signac-1.2.0:
           requires:
             - test-3.7
       - test-deploy-pypi:
@@ -185,16 +199,18 @@ workflows:
               only: /release\/.*/
           requires:
             - test-2.7
-            - test-2.7-signac-0.9.0
-            - test-2.7-signac-0.9.4
+            - test-2.7-signac-0.9.5
             - test-2.7-signac-1.0.0
+            - test-2.7-signac-1.1.0
+            - test-2.7-signac-1.2.0
             - test-3.4
             - test-3.5
             - test-3.6
             - test-3.7
-            - test-3.7-signac-0.9.0
-            - test-3.7-signac-0.9.4
+            - test-3.7-signac-0.9.5
             - test-3.7-signac-1.0.0
+            - test-3.7-signac-1.1.0
+            - test-3.7-signac-1.2.0
   deploy:
     jobs:
       - deploy-pypi:


### PR DESCRIPTION
Update the signac core version we test against.

Includes the previous 4 minor releases: (0.9.5, 1.0.0, 1.1.0, 1.2.0).