### PR TITLE
automatically add --smpiargs='-gpu' option for cuda-aware MPI

### DIFF
--- a/flow/environments/incite.py
+++ b/flow/environments/incite.py
@@ -72,7 +72,8 @@ class SummitEnvironment(DefaultLSFEnvironment):
     @staticmethod
     def jsrun_options(resource_set):
         nsets, tasks, cpus, gpus = resource_set
-        return '-n {} -a {} -c {} -g {}'.format(nsets, tasks, cpus, gpus)
+        cuda_aware_mpi = "--smpiargs='-gpu'" if (nsets > 0 or tasks > 0) and gpus > 0 else ""
+        return '-n {} -a {} -c {} -g {} {}'.format(nsets, tasks, cpus, gpus, cuda_aware_mpi)
 
     @staticmethod
     def jsrun_extra_args(operation):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR selects the cuda-aware option of the MPI library by default, if GPUs and multiple ranks are involved. See https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#cuda-aware-mpi

## Motivation and Context
It makes job scripts more portable, as the Summit specific `extra_jsrun_args` directive is now optional. This way, job scripts do not need to contain Summit specific options to run with code that relies on cuda-aware MPI support.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
