### PR TITLE
Raise error if subprocess returns non-zero exit code.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,10 @@ Added
 
 - Add "fork" directive to enforce the execution of operations within a subprocess.
 
+Changed
++++++++
+- Raise errors if a forked process or ``@cmd`` operation returns a non-zero exit code. (#170, #172).
+
 Removed
 +++++++
 - Drop support for Python version 2.7.

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -244,7 +244,7 @@ def run(parser=None):
 
         def operation(job):
             cmd = operation_func(job).format(job=job)
-            subprocess.call(cmd, shell=True, timeout=args.timeout)
+            subprocess.run(cmd, shell=True, timeout=args.timeout, check=True)
     else:
         operation = operation_func
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -1540,7 +1540,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             logger.debug(
                 "Forking to execute operation '{}' with "
                 "cmd '{}'.".format(operation, operation.cmd))
-            subprocess.call(operation.cmd, shell=True, timeout=timeout)
+            returncode = subprocess.call(operation.cmd, shell=True, timeout=timeout)
+            if returncode != 0:
+                logger.warning("Operation '{}' called via subprocess returned "
+                               "nonzero code: {}.".format(
+                                   operation, returncode))
         else:
             # ... executing operation in interpreter process as function:
             logger.debug(

--- a/flow/project.py
+++ b/flow/project.py
@@ -1540,11 +1540,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             logger.debug(
                 "Forking to execute operation '{}' with "
                 "cmd '{}'.".format(operation, operation.cmd))
-            returncode = subprocess.call(operation.cmd, shell=True, timeout=timeout)
-            if returncode != 0:
-                logger.warning("Operation '{}' called via subprocess returned "
-                               "nonzero code: {}.".format(
-                                   operation, returncode))
+            subprocess.run(operation.cmd, shell=True, timeout=timeout, check=True)
         else:
             # ... executing operation in interpreter process as function:
             logger.debug(
@@ -2630,7 +2626,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
                 def operation_function(job):
                     cmd = operation(job).format(job=job)
-                    subprocess.call(cmd, shell=True)
+                    subprocess.run(cmd, shell=True, check=True)
 
         except KeyError:
             raise KeyError("Unknown operation '{}'.".format(args.operation))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -389,8 +389,9 @@ class ProjectClassTest(BaseProjectTest):
         with add_cwd_to_environment_pythonpath():
             with switch_to_directory(project.root_directory()):
                 starting_dir = os.getcwd()
-                with redirect_stderr(StringIO()):
-                    A().run()
+                with self.assertRaises(subprocess.CalledProcessError):
+                    with redirect_stderr(StringIO()):
+                        A().run()
                 self.assertEqual(os.getcwd(), starting_dir)
 
     def test_function_in_directives(self):


### PR DESCRIPTION
## Description
This PR raises an error `subprocess.CalledProcessError` if a forked or `@cmd` operation returns a non-zero exit code. Users should wrap their operations if a non-zero code is expected.

## Motivation and Context
See #170.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
