### PR TITLE
Add 'current_version' argument to deprecated calls.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,7 +4,7 @@ commit = True
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:flow/__init__.py]
+[bumpversion:file:flow/version.py]
 
 [bumpversion:file:doc/conf.py]
 

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -25,14 +25,13 @@ from .environment import get_environment
 from .template import init
 from .util.misc import redirect_log
 from .operations import with_job
+from .version import __version__
 
 # Import packaged environments unless disabled in config:
 from .util.config import get_config_value
 if get_config_value('import_packaged_environments', default=True):
     from . import environments  # noqa:F401
 
-
-__version__ = '0.8.0'
 
 __all__ = [
     'environment',
@@ -50,5 +49,6 @@ __all__ = [
     'redirect_log',
     'get_environment',
     'with_job',
-    'testing'
+    'testing',
+    '__version__'
     ]

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -50,5 +50,5 @@ __all__ = [
     'get_environment',
     'with_job',
     'testing',
-    '__version__'
+    '__version__',
     ]

--- a/flow/legacy_templating.py
+++ b/flow/legacy_templating.py
@@ -11,6 +11,7 @@ import warnings
 import functools
 import deprecation
 
+from .version import __version__
 
 NUM_NODES_WARNING = """Unable to determine the reqired number of nodes (nn) for this submission.
 Either provide this value directly with '--nn' or provide the number of processors
@@ -259,6 +260,7 @@ def deprecated_since_06(func):
 
     return deprecation.deprecated(
         deprecated_in=0.6, removed_in=0.8,
+        current_version=__version__,
         details="This function is part of the legacy templating system.")(func)
 
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -66,6 +66,7 @@ from .labels import classlabel
 from .labels import _is_label_func
 from . import legacy
 from .util import config as flow_config
+from .version import __version__
 
 
 logger = logging.getLogger(__name__)
@@ -730,7 +731,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             return x
 
     @classmethod
-    @deprecated(deprecated_in="0.8", removed_in="1.0")
+    @deprecated(
+        deprecated_in="0.8", removed_in="1.0",
+        current_version=__version__)
     def update_aliases(cls, aliases):
         "Update the ALIASES table for this class."
         cls.ALIASES.update(aliases)
@@ -2102,7 +2105,10 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             help="Manually specify all labels that are required for the direct command "
                  "to be considered eligible for execution.")
 
-    @deprecated(deprecated_in="0.8", removed_in="1.0", details="Use export_job_statuses() instead.")
+    @deprecated(
+        deprecated_in="0.8", removed_in="1.0",
+        current_version=__version__,
+        details="Use export_job_statuses() instead.")
     def export_job_stati(self, collection, stati):
         "Export the job stati to a database collection."
         self.export_job_statuses(self, collection, stati)
@@ -2288,7 +2294,10 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             raise KeyError("An operation with this identifier is already added.")
         self.operations[name] = FlowOperation(cmd=cmd, pre=pre, post=post, directives=kwargs)
 
-    @deprecated(deprecated_in="0.8", removed_in="1.0", details="Use labels() instead.")
+    @deprecated(
+        deprecated_in="0.8", removed_in="1.0",
+        current_version=__version__,
+        details="Use labels() instead.")
     def classify(self, job):
         """Generator function which yields labels for job.
 
@@ -2343,7 +2352,10 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             for op in self._job_operations(job, True):
                 yield op
 
-    @deprecated(deprecated_in="0.8", removed_in="1.0", details="Use next_operations() instead.")
+    @deprecated(
+        deprecated_in="0.8", removed_in="1.0",
+        current_version=__version__,
+        details="Use next_operations() instead.")
     def next_operation(self, job):
         """Determine the next operation for this job.
 
@@ -2479,7 +2491,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             return False
         return True
 
-    @deprecated(deprecated_in="0.8", removed_in="1.0")
+    @deprecated(
+        deprecated_in="0.8", removed_in="1.0",
+        current_version=__version__)
     def eligible_for_submission(self, job_operation):
         return self._eligible_for_submission(self, job_operation)
 

--- a/flow/util/progressbar.py
+++ b/flow/util/progressbar.py
@@ -5,8 +5,10 @@
 import sys
 from deprecation import deprecated
 
+from .version import __version__
 
-@deprecated(deprecated_in="0.8", removed_in="1.0")
+
+@deprecated(deprecated_in="0.8", removed_in="1.0", current_version=__version__)
 def with_progressbar(iterable, total=None, width=120, desc='',
                      percentage=True, file=None):
     if file is None:

--- a/flow/version.py
+++ b/flow/version.py
@@ -4,4 +4,4 @@
 
 __all__ = ['__version__']
 
-__version__ = '0.9.0'
+__version__ = '0.8.0'

--- a/flow/version.py
+++ b/flow/version.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+
+__all__ = ['__version__']
+
+__version__ = '0.9.0'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -27,6 +27,7 @@ from flow.util.misc import add_path_to_environment_pythonpath
 from flow.util.misc import add_cwd_to_environment_pythonpath
 from flow.util.misc import switch_to_directory
 from flow import init
+from deprecation import fail_if_not_removed
 
 from define_test_project import TestProject
 from define_test_project import TestDynamicProject
@@ -513,6 +514,7 @@ class ProjectTest(BaseProjectTest):
     def test_instance(self):
         self.assertTrue(isinstance(self.project, FlowProject))
 
+    @fail_if_not_removed
     def test_labels(self):
         project = self.mock_project()
         for job in project:
@@ -860,6 +862,7 @@ class ExecutionProjectTest(BaseProjectTest):
             project.submit(bundle_size=0)
             self.assertEqual(len(list(MockScheduler.jobs())), 1)
 
+    @fail_if_not_removed
     def test_submit_status(self):
         MockScheduler.reset()
         project = self.mock_project()
@@ -914,6 +917,7 @@ class ExecutionProjectTest(BaseProjectTest):
                       'used by the template script, including: bad_directive\n',
                       stderr.getvalue())
 
+    @fail_if_not_removed
     def test_condition_evaluation(self):
         project = self.mock_project()
 


### PR DESCRIPTION
To make sure that future deprecations are triggered for the right
versions and that unit tests can automatically fail when a particular
deprecated element has not actually been removed.

While reviewing #179 I noticed that we don't actually pass the `current_version` argument to the `deprecated` calls which makes it harder for the library to issue correct warnings and impossible for automatic failure of unit tests if we failed to remove deprecated elements.