### PR TITLE
Prevent failure on operation creation when inspection fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Added
 
 Changed
 +++++++
+- Only call ``inspect.getsourcefile`` in ``guess_cmd`` if ``_flow_path`` is not set (#197).
 - Raise errors if a forked process or ``@cmd`` operation returns a non-zero exit code. (#170, #172).
 
 Removed

--- a/flow/project.py
+++ b/flow/project.py
@@ -2585,7 +2585,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                     path = inspect.getsourcefile(inspect.getmodule(func))
                 except TypeError:
                     raise RuntimeError("Cannot find file associated with "
-                                       "function {}. Specify `_func_path` "
+                                       "function {}. Specify `_flow_path` "
                                        "to use.".format(name))
             cmd_str = "{} {} exec {} {{job._id}}"
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -2578,7 +2578,15 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             except (KeyError, TypeError):
                 executable = sys.executable
 
-            path = getattr(func, '_flow_path', inspect.getsourcefile(inspect.getmodule(func)))
+            if hasattr(func, '_flow_path'):
+                path = func._flow_path
+            else:
+                try:
+                    path = inspect.getsourcefile(inspect.getmodule(func))
+                except TypeError:
+                    raise RuntimeError("Cannot find file associated with "
+                                       "function {}. Specify `_func_path` "
+                                       "to use.".format(name))
             cmd_str = "{} {} exec {} {{job._id}}"
 
             if callable(executable):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
In `guess_cmd`, for certain `functool` objects, `inspect.getsourcefile` can fail which prevents the creation of the operation. A fix for this is to allow  setting `_flow_path`  to avoid calling `inspect.getsourcefile`. This just changes the logic's flow to allow for `_flow_path` to prevent `inspect.getsourcefile` be called.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See above

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
