### PR TITLE
Replace mode argument with partition

### DIFF
--- a/flow/environments/umich.py
+++ b/flow/environments/umich.py
@@ -19,7 +19,7 @@ class GreatLakesEnvironment(DefaultSlurmEnvironment):
         super(GreatLakesEnvironment, cls).add_args(parser)
         parser.add_argument(
             '--partition',
-            choices=('standard', 'gpu'),
+            choices=('standard', 'gpu', 'largemem'),
             default='standard',
             help="Specify whether to submit to the CPU or the GPU queue. "
                  "(default=standard)")

--- a/flow/environments/umich.py
+++ b/flow/environments/umich.py
@@ -21,7 +21,7 @@ class GreatLakesEnvironment(DefaultSlurmEnvironment):
             '--partition',
             choices=('standard', 'gpu', 'largemem'),
             default='standard',
-            help="Specify whether to submit to the CPU or the GPU queue. "
+            help="Specify the partition to submit to. "
                  "(default=standard)")
         parser.add_argument(
             '--memory',

--- a/flow/environments/umich.py
+++ b/flow/environments/umich.py
@@ -18,11 +18,11 @@ class GreatLakesEnvironment(DefaultSlurmEnvironment):
     def add_args(cls, parser):
         super(GreatLakesEnvironment, cls).add_args(parser)
         parser.add_argument(
-            '--mode',
-            choices=('cpu', 'gpu'),
-            default='cpu',
+            '--partition',
+            choices=('standard', 'gpu'),
+            default='standard',
             help="Specify whether to submit to the CPU or the GPU queue. "
-                 "(default=cpu)")
+                 "(default=standard)")
         parser.add_argument(
             '--memory',
             default='4g',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
<!-- Describe your changes in detail -->
Allows the user to specify the partition with the --partition flag like for other Slurm clusters.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There was no way to submit to a GPU cluster on Great Lakes before this.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
