### PR TITLE
Use provided label name over function name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,10 @@ Changed
 - The command line option ``--cmd`` for ``script`` has been deprecated and will trigger a ``DeprecationWarning`` upon use until removed (#243, #218).
 - Raises ValueError when --job-name passed by the user because that interferes with status checking (#164, #241).
 
+Fixed
++++++
+- Ensure that label names are used when displaying status (#263).
+
 Removed
 +++++++
 - Removed ENVIRONMENT global variable in the flow.environment module (#245).

--- a/flow/project.py
+++ b/flow/project.py
@@ -2894,8 +2894,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         """
         for label_func, label_name in self._label_functions.items():
             if label_name is None:
-                label_name = getattr(label, '_label_name',
-                                     getattr(label, '__name__', type(label).__name__))
+                label_name = getattr(label_func, '_label_name',
+                                     getattr(label_func, '__name__', type(label_func).__name__))
             try:
                 label_value = label_func(job)
             except TypeError:
@@ -2905,7 +2905,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                     label_func = getattr(self, label.__func__.__name__)
                     label_value = label_func(job)
 
-            label_name = getattr(label_func, '_label_name', label_func.__name__)
             assert label_name is not None
             if isinstance(label_value, str):
                 yield label_value

--- a/tests/define_test_project.py
+++ b/tests/define_test_project.py
@@ -22,6 +22,11 @@ def negative_default_label(job):
     return False
 
 
+@_TestProject.label('named_label')
+def anonymous_label(job):
+    return True
+
+
 @_TestProject.label
 def b_is_even(job):
     try:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -547,10 +547,12 @@ class TestProject(TestProjectBase):
         project = self.mock_project()
         for job in project:
             labels = list(project.classify(job))
-            assert len(labels) == 2 - (job.sp.b % 2)
+            assert len(labels) == 3 - (job.sp.b % 2)
             assert all(isinstance(l, str) for l in labels)
             assert 'default_label' in labels
             assert 'negative_default_label' not in labels
+            assert 'named_label' in labels
+            assert 'anonymous_label' not in labels
 
     def test_next_operations(self):
         project = self.mock_project()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Label names were being ignored by the existing code, so doing something like
```
@Project.label('real_name')
def fake_name(job):
    return True
```
would always print `fake_name` instead of `real_name`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes a bug.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
