### PR TITLE
Match the flake8 command we use for signac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: check-code-style
           command: |
-            python -m flake8 --show-source flow/
+            python -m flake8 --show-source .
 
   test-3.8: &test-template
     environment:


### PR DESCRIPTION
I noticed that we don't flake8 our unit tests in signac-flow, this fixes that.