### PR TITLE
Use buffered behavior by default for performance in status checks.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Changed
 - The command line option ``--cmd`` for ``script`` has been deprecated and will trigger a ``DeprecationWarning`` upon use until removed (#243, #218).
 - Raises ValueError when --job-name passed by the user because that interferes with status checking (#164, #241).
 - Submitting with ``--memory`` no longer assumes a unit of gigabytes on Bridges and Comet clusters (#257).
+- Buffering is enabled by default, improving the performance of status checks (#273).
 
 Removed
 +++++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -1171,12 +1171,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         self._groups = dict()
         self._register_groups()
 
-        # Enable the use of buffered mode for certain functions
-        try:
-            self._use_buffered_mode = self.config['flow'].as_bool('use_buffered_mode')
-        except KeyError:
-            self._use_buffered_mode = False
-
     def _setup_template_environment(self):
         """Setup the jinja2 template environment.
 
@@ -2393,7 +2387,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     @contextlib.contextmanager
     def _potentially_buffered(self):
-        if self._use_buffered_mode:
+        """Enable the use of buffered mode for certain functions."""
+        if self.config['flow'].as_bool('use_buffered_mode'):
             logger.debug("Entering buffered mode...")
             with signac.buffered():
                 yield

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -15,6 +15,7 @@ import_packaged_environments = boolean()
 status_performance_warn_threshold = float(default=0.2)
 show_traceback = boolean()
 eligible_jobs_max_lines = int(default=10)
+use_buffered_mode = boolean(default=True)
 """
 
 


### PR DESCRIPTION
## Description
Improves performance in status checks by enabling signac's buffering feature.

## Motivation and Context
Status check was slow, performance profiling with `python -m cProfile -o out.prof project.py submit --pretend` showed that the slowest parts could be improved enabling buffering. Enabling buffering made the slow parts faster.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
