### PR TITLE
Fix issue with 'test_with_job_decorator' unit test.

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -320,7 +320,7 @@ class TestProjectClass(TestProjectBase):
         @A.operation
         @with_job
         def test_context(job):
-            assert os.getcwd() == job.ws
+            assert os.path.realpath(os.getcwd()) == os.path.realpath(job.ws)
 
         project = self.mock_project(A)
         with add_cwd_to_environment_pythonpath():


### PR DESCRIPTION
The path comparison was done without 'realpath' wrapper, which causes
issues on Mac OS-X, because the temporary paths are represented
differently depending on context.
