### PR TITLE
synce legend for operation status

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -98,6 +98,18 @@ For example: {{{{ project.get_id() | capitalize }}}}.
 The available filters are:
 {filters}"""
 
+_FMT_SCHEDULER_STATUS = {
+    JobStatus.unknown: 'U',
+    JobStatus.registered: 'R',
+    JobStatus.inactive: 'I',
+    JobStatus.submitted: 'S',
+    JobStatus.held: 'H',
+    JobStatus.queued: 'Q',
+    JobStatus.active: 'A',
+    JobStatus.error: 'E',
+    JobStatus.dummy: ' ',
+}
+
 
 class IgnoreConditions(IntEnum):
     """Flags that determine which conditions are used to determine job eligibility.
@@ -1405,16 +1417,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         for cls in type(self).__mro__:
             self._label_functions.update(getattr(cls, '_LABEL_FUNCTIONS', dict()))
 
-    ALIASES = dict(
-        unknown='U',
-        registered='R',
-        inactive='I',
-        submitted='S',
-        held='H',
-        queued='Q',
-        active='A',
-        error='E'
-    )
+    ALIASES = {str(status).replace('JobStatus.', ''): symbol
+               for status, symbol in _FMT_SCHEDULER_STATUS.items() if status != JobStatus.dummy}
     "These are default aliases used within the status output."
 
     @classmethod
@@ -3710,19 +3714,6 @@ def _execute_serialized_operation(loads, project, operation):
 
 
 # Status-related helper functions
-
-
-_FMT_SCHEDULER_STATUS = {
-    JobStatus.unknown: 'U',
-    JobStatus.registered: 'R',
-    JobStatus.inactive: 'I',
-    JobStatus.submitted: 'S',
-    JobStatus.held: 'H',
-    JobStatus.queued: 'Q',
-    JobStatus.active: 'A',
-    JobStatus.error: 'E',
-    JobStatus.dummy: ' ',
-}
 
 
 def _update_status(args):

--- a/flow/project.py
+++ b/flow/project.py
@@ -1408,10 +1408,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
     ALIASES = dict(
         unknown='U',
         registered='R',
+        inactive='I',
+        submitted='S',
+        held='H',
         queued='Q',
         active='A',
-        inactive='I',
-        requires_attention='!'
+        error='E'
     )
     "These are default aliases used within the status output."
 


### PR DESCRIPTION
synce legend for operation status in #284 


## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
