### PR TITLE
refactoring submit execution flow to include submit() function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ Changed
 - Raises ValueError when --job-name passed by the user because that interferes with status checking (#164, #241).
 - Submitting with ``--memory`` no longer assumes a unit of gigabytes on Bridges and Comet clusters (#257).
 - Buffering is enabled by default, improving the performance of status checks (#273).
+- Submission via the command-line interface now calls the ``FlowProject.submit`` function instead of bypassing it for ``FlowProject.submit_operations``(#238, #286).
 
 Fixed
 +++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -2607,20 +2607,18 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 "must be a member of class IgnoreConditions")
 
         # Gather all pending operations.
-        default_directives = self._get_default_directives()
         with self._potentially_buffered():
-            operations = self._get_submission_operations(jobs, default_directives, names, parallel,
-                                                         ignore_conditions,
+            default_directives = self._get_default_directives()
+            operations = self._get_submission_operations(jobs, default_directives, names,
+                                                         parallel, ignore_conditions,
                                                          ignore_conditions_on_execution)
         if num is not None:
             operations = list(islice(operations, num))
 
         # Bundle them up and submit.
         for bundle in _make_bundles(operations, bundle_size):
-            status = self.submit_operations(
-                operations=bundle, env=env, parallel=parallel,
-                force=force, walltime=walltime, **kwargs)
-
+            status = self.submit_operations(operations=bundle, env=env, parallel=parallel,
+                                            force=force, walltime=walltime, **kwargs)
             if status is not None:  # operations were submitted, store status
                 for operation in bundle:
                     operation.set_status(status)
@@ -3378,7 +3376,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         if not args.test:
             self._fetch_scheduler_status(jobs)
 
-        self.submit(jobs=jobs, **kwargs)
+        names = args.operation_name if args.operation_name else None
+        self.submit(jobs=jobs, names=names, **kwargs)
 
     def _main_exec(self, args):
         if len(args.jobid):

--- a/flow/project.py
+++ b/flow/project.py
@@ -2608,7 +2608,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         # Gather all pending operations.
         default_directives = self._get_default_directives()
-        names = args.operation_name if args.operation_name else None
         with self._potentially_buffered():
             operations = self._get_submission_operations(jobs, default_directives, names, parallel,
                                                          ignore_conditions,

--- a/flow/project.py
+++ b/flow/project.py
@@ -2623,8 +2623,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 force=force, walltime=walltime, **kwargs)
 
             if status is not None:  # operations were submitted, store status
-                for operations in bundle:
-                    operations.set_status(status)
+                for operation in bundle:
+                    operation.set_status(status)
 
     @classmethod
     def _add_submit_args(cls, parser):

--- a/flow/project.py
+++ b/flow/project.py
@@ -3378,7 +3378,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         if not args.test:
             self._fetch_scheduler_status(jobs)
 
-        submit(jobs=jobs, **kwargs)
+        self.submit(jobs=jobs, **kwargs)
 
     def _main_exec(self, args):
         if len(args.jobid):


### PR DESCRIPTION
partially addresses #238 

## Description

Refactoring the `submit` execution to be:

FlowProject.main() -> FlowProject._main_submit() -> FlowProject.submit() -> submit_operations()


## Motivation and Context
See #238. Currently the `submit()` function was not being called by `_main_submit()`, and `_main_submit()` was replicating the logic.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
