### PR TITLE
Drop Support for Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,10 +96,6 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.6
-  test-3.5:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5
 
   test-deploy-pypi:
     docker:
@@ -133,9 +129,6 @@ workflows:
             branches:
               only: /release\/.*/
       - pre-test-checks
-      - test-3.5:
-          requires:
-            - pre-test-checks
       - test-3.6:
           requires:
             - pre-test-checks
@@ -159,7 +152,6 @@ workflows:
             branches:
               only: /release\/.*/
           requires:
-            - test-3.5
             - test-3.6
             - test-3.7
             - test-3.8

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ That includes the definition of data pipelines, execution of data space operatio
 ## Installation
 
 The recommended installation method for **signac-flow** is through **conda** or **pip**.
-The software is tested for Python versions 3.5+ and is built for all major platforms.
+The software is tested for Python versions 3.6+ and is built for all major platforms.
 
 To install **signac-flow** *via* the [conda-forge](https://conda-forge.github.io/) channel, execute:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,21 @@
-=======
+======
 Changes
 =======
 
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
+
+next
+====
+
+next
+----
+
+Removed
++++++++
+
+- Dropped support for Python 3.5 (#305). The signac project will follow the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_ going forward.
+
 
 Version 0.10
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ next
 Removed
 +++++++
 
-- Dropped support for Python 3.5 (#305). The signac project will follow the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_ going forward.
+- Drop support for Python 3.5 (#305). The signac project will follow the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_ going forward.
 
 
 Version 0.10

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,7 +5,8 @@ Installation
 ============
 
 The recommended installation method for **signac-flow** is via conda_ or pip_.
-The software is tested for Python versions 3.5+ and signac_ versions 1.0+.
+The software is tested for Python versions 3.6+ and signac_ versions 1.0+.
+Supported Python and NumPy versions are determined according to the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
 
 .. _conda: https://conda.io/
 .. _conda-forge: https://conda-forge.org/

--- a/flow/project.py
+++ b/flow/project.py
@@ -45,7 +45,7 @@ from signac.contrib.hashing import calc_id
 from signac.contrib.filterparse import parse_filter_arg
 from signac.contrib.project import JobsCursor
 
-from enum import IntEnum
+from enum import IntFlag
 
 from .environment import get_environment
 from .scheduling.base import ClusterJob
@@ -111,9 +111,7 @@ _FMT_SCHEDULER_STATUS = {
 }
 
 
-# TODO: When we drop Python 3.5 support, change this to inherit from IntFlag
-# instead of IntEnum so that we can remove the operator overloads.
-class IgnoreConditions(IntEnum):
+class IgnoreConditions(IntFlag):
     """Flags that determine which conditions are used to determine job eligibility.
 
     The options include:
@@ -122,29 +120,11 @@ class IgnoreConditions(IntEnum):
         * IgnoreConditions.POST: ignore post conditions
         * IgnoreConditions.ALL: ignore all conditions
     """
-    # The following three functions can be removed once we drop Python 3.5
-    # support, they are implemented by the IntFlag class in Python > 3.6.
-    def __or__(self, other):
-        if not isinstance(other, (self.__class__, int)):
-            return NotImplemented
-        result = self.__class__(self._value_ | self.__class__(other)._value_)
-        return result
-
-    def __and__(self, other):
-        if not isinstance(other, (self.__class__, int)):
-            return NotImplemented
-        return self.__class__(self._value_ & self.__class__(other)._value_)
-
-    def __xor__(self, other):
-        if not isinstance(other, (self.__class__, int)):
-            return NotImplemented
-        return self.__class__(self._value_ ^ self.__class__(other)._value_)
-
     # This operator must be defined since IntFlag simply performs an integer
     # bitwise not on the underlying enum value, which is problematic in
     # twos-complement arithmetic. What we want is to only flip valid bits.
     def __invert__(self):
-        # Compute the largest number of bits use to represent one of the flags
+        # Compute the largest number of bits used to represent one of the flags
         # so that we can XOR the appropriate number.
         max_bits = len(bin(max([elem.value for elem in type(self)]))) - 2
         return self.__class__((2**max_bits - 1) ^ self._value_)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Physics",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -67,5 +66,7 @@ setup(
 
     install_requires=requirements,
 
-    python_requires='>=3.5, <4',
+    # Supported versions are determined according to NEP 29.
+    # https://numpy.org/neps/nep-0029-deprecation_policy.html
+    python_requires='>=3.6, <4',
 )


### PR DESCRIPTION
## Description
This PR drops support for Python 3.5 and adopts NEP 29.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).