### PR TITLE
Update tested signac versions to 1.3.0 and 1.4.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,14 +80,14 @@ jobs:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "v1.0.0"
-  test-3.8-signac-1.2.0:
-    <<: *test-template
-    environment:
-      SIGNAC_VERSION: "v1.2.0"
   test-3.8-signac-1.3.0:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "v1.3.0"
+  test-3.8-signac-1.4.0:
+    <<: *test-template
+    environment:
+      SIGNAC_VERSION: "v1.4.0"
   test-3.7:
     <<: *test-template
     docker:
@@ -141,10 +141,10 @@ workflows:
       - test-3.8-signac-1.0.0:
           requires:
             - test-3.8
-      - test-3.8-signac-1.2.0:
+      - test-3.8-signac-1.3.0:
           requires:
             - test-3.8
-      - test-3.8-signac-1.3.0:
+      - test-3.8-signac-1.4.0:
           requires:
             - test-3.8
       - test-deploy-pypi:
@@ -156,8 +156,8 @@ workflows:
             - test-3.7
             - test-3.8
             - test-3.8-signac-1.0.0
-            - test-3.8-signac-1.2.0
             - test-3.8-signac-1.3.0
+            - test-3.8-signac-1.4.0
   deploy:
     jobs:
       - deploy-pypi:


### PR DESCRIPTION
We aim to test the two most recent minor versions and one major version of signac with signac-flow. This updates from 1.0.0, 1.2.0, and 1.3.0 to 1.0.0, 1.3.0, and 1.4.0.

Merge this PR when CI passes.