### PR TITLE
Skip test_status_performance for signac version < 1.3.0

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -167,8 +167,9 @@ class TestProjectStatusPerformance(TestProjectBase):
 
     @pytest.mark.skipif(signac.__version__ < '1.3.0',
                         reason='Project.__contains__ was refactored to run in constant time '
-                               'in signac version 1.3.0. This test takes up a lot of time, hence '
-                               'skipped, for signac versions below 1.3.0.')
+                               'in signac version 1.3.0. Generating status output relies on '
+                               'this check and is therefore very slow for signac versions '
+                               'below 1.3.0.')
     def test_status_performance(self):
         """Ensure that status updates take less than 1 second for a data space of 1000 jobs."""
         import timeit

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -165,6 +165,8 @@ class TestProjectStatusPerformance(TestProjectBase):
             project.open_job(dict(i=i)).init()
         return project
 
+    @pytest.mark.skipif(signac.__version__ < '1.3.0',
+                        reason='__contains__ was refactored to run in constant time in 1.3.0 ')
     def test_status_performance(self):
         """Ensure that status updates take less than 1 second for a data space of 1000 jobs."""
         import timeit

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -166,7 +166,9 @@ class TestProjectStatusPerformance(TestProjectBase):
         return project
 
     @pytest.mark.skipif(signac.__version__ < '1.3.0',
-                        reason='__contains__ was refactored to run in constant time in 1.3.0 ')
+                        reason='Project.__contains__ was refactored to run in constant time '
+                               'in signac version 1.3.0. This test takes up a lot of time, hence '
+                               'skipped, for signac versions below 1.3.0.')
     def test_status_performance(self):
         """Ensure that status updates take less than 1 second for a data space of 1000 jobs."""
         import timeit


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Since `__contains__` was refactored in signac _version 1.3.0_ to run in constant time in the pull request [signac/321](https://github.com/glotzerlab/signac/pull/231), the `test_status_performance` takes up a lot of time for the versions below _1.3.0_.
Hence skipping the `test_status_performance` for versions below _1.3.0_.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves the failing tests for #324 
## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
