### PR TITLE
Move information on parallelization to the subparser description rather than the overall help

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -3738,11 +3738,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         parser_status = subparsers.add_parser(
             'status',
             parents=[base_parser],
-            help="You can specify the parallelization of the status command "
-                 "by setting the flow.status_parallelization config "
-                 "value to 'thread' (default), 'none', or 'process'. You can do this by "
-                 "executing `signac config set flow.status_parallelization "
-                 "VALUE`.")
+            description="You can specify the parallelization of the status "
+                        "command by setting the flow.status_parallelization "
+                        "config value to 'thread' (default), 'none', or "
+                        "'process'. You can do this by executing `signac "
+                        "config set flow.status_parallelization VALUE`.")
         self._add_print_status_args(parser_status)
         parser_status.add_argument(
             '--profile',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

The status subparser help is currently added using the `help` argument to `subparsers.add_parser`. This PR changes it to use the `description` argument.

No changelog/credits/etc changes are necessary.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The content of the help string is to indicate the possibility of specifying the type of parallelism to use during a status update. This is too specific to show when running `python project.py -h`, and is more appropriate to show when doing `python project.py status -h`. The `help` for the subparser (which is what is shown when doing `python project.py -h`) is intended for short information like "Print the status of all jobs in the workspace associated with this project."

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
