### PR TITLE
Fix performance regression in job submission.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
-=======
-Changes
-=======
+=========
+Changelog
+=========
 
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
@@ -26,6 +26,7 @@ Changed
 Fixed
 +++++
 - Serial execution on Summit correctly counts total node requirements (#342).
+- Fixed performance regression in job submission in large workspaces (#354).
 
 Removed
 +++++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -3027,10 +3027,15 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # Gather all pending operations.
         with self._potentially_buffered():
             default_directives = self._get_default_directives()
-            # The generator must be used *inside* the buffering context manager for performance reasons
-            operation_generator = self._get_submission_operations(
-                jobs, default_directives, names, ignore_conditions, ignore_conditions_on_execution)
-            # islice takes the first "num" elements from the generator, or all items if num is None
+            # The generator must be used *inside* the buffering context manager
+            # for performance reasons
+            operation_generator = self._get_submission_operations(jobs,
+                                                                  default_directives,
+                                                                  names,
+                                                                  ignore_conditions,
+                                                                  ignore_conditions_on_execution)
+            # islice takes the first "num" elements from the generator, or all
+            # items if num is None
             operations = list(islice(operation_generator, num))
 
         # Bundle them up and submit.

--- a/flow/project.py
+++ b/flow/project.py
@@ -3035,7 +3035,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                                                                   ignore_conditions,
                                                                   ignore_conditions_on_execution)
             # islice takes the first "num" elements from the generator, or all
-            # items if num is None
+            # items if num is None.
             operations = list(islice(operation_generator, num))
 
         # Bundle them up and submit.

--- a/flow/project.py
+++ b/flow/project.py
@@ -3028,7 +3028,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         with self._potentially_buffered():
             default_directives = self._get_default_directives()
             # The generator must be used *inside* the buffering context manager
-            # for performance reasons
+            # for performance reasons.
             operation_generator = self._get_submission_operations(jobs,
                                                                   default_directives,
                                                                   names,

--- a/flow/project.py
+++ b/flow/project.py
@@ -3027,11 +3027,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # Gather all pending operations.
         with self._potentially_buffered():
             default_directives = self._get_default_directives()
-            operations = self._get_submission_operations(jobs, default_directives, names,
-                                                         ignore_conditions,
-                                                         ignore_conditions_on_execution)
-        if num is not None:
-            operations = list(islice(operations, num))
+            # The generator must be used *inside* the buffering context manager for performance reasons
+            operation_generator = self._get_submission_operations(
+                jobs, default_directives, names, ignore_conditions, ignore_conditions_on_execution)
+            # islice takes the first "num" elements from the generator, or all items if num is None
+            operations = list(islice(operation_generator, num))
 
         # Bundle them up and submit.
         for bundle in _make_bundles(operations, bundle_size):

--- a/flow/project.py
+++ b/flow/project.py
@@ -3039,12 +3039,16 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             operations = list(islice(operation_generator, num))
 
         # Bundle them up and submit.
-        for bundle in _make_bundles(operations, bundle_size):
-            status = self._submit_operations(operations=bundle, env=env, parallel=parallel,
-                                             force=force, walltime=walltime, **kwargs)
-            if status is not None:  # operations were submitted, store status
-                for operation in bundle:
-                    operation.set_status(status)
+        with self._potentially_buffered():
+            for bundle in _make_bundles(operations, bundle_size):
+                status = self._submit_operations(operations=bundle, env=env,
+                                                 parallel=parallel,
+                                                 force=force,
+                                                 walltime=walltime, **kwargs)
+                if status is not None:
+                    # Operations were submitted, store status
+                    for operation in bundle:
+                        operation.set_status(status)
 
     @classmethod
     def _add_submit_args(cls, parser):


### PR DESCRIPTION
## Description
Corrects a serious performance regression in job submission, introduced in 7e2722fe25bf5fcf3009a5b77e28e187a5eb8050.
Makes sure the `operations` generator is consumed *inside* the buffering context manager.

I also added a second buffered region during submission, so that status updates do not immediately write to the project document (only when finished, an error occurs, or the process is gracefully interrupted, all of which will trigger the context manager's exit and cause a flush to disk). Without buffering, this region is very expensive in large projects (which need to read/write the project document for every job that is submitted).

## Motivation and Context
Submission was very slow in a large workspace (100k jobs).

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
