### PR TITLE
Nightly CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ workflows:
       - test-3.8-signac-1.4:
           requires:
             - test-3.8
+      - test-3.8-signac-latest
       - test-deploy-pypi:
           filters:
             branches:
@@ -158,7 +159,6 @@ workflows:
             - test-3.8-signac-1.0
             - test-3.8-signac-1.3
             - test-3.8-signac-1.4
-            - test-3.8-signac-latest
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ workflows:
       - test-3.8-signac-1.4:
           requires:
             - test-3.8
-      - test-3.8-signac-latest
       - test-deploy-pypi:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
 
   test-3.8: &test-template
     environment:
-      SIGNAC_VERSION: ""
+      SIGNAC_VERSION: "signac"
     docker:
       - image: circleci/python:3.8
 
@@ -56,7 +56,7 @@ jobs:
             mkdir -p ./venv
             python -m virtualenv ./venv
             . venv/bin/activate
-            pip install signac${SIGNAC_VERSION}
+            pip install ${SIGNAC_VERSION}
             pip install -r requirements.txt
             pip install -r requirements-test.txt
             pip install -U coverage mock
@@ -75,15 +75,19 @@ jobs:
   test-3.8-signac-1.0:
     <<: *test-template
     environment:
-      SIGNAC_VERSION: "~=1.0.0"
+      SIGNAC_VERSION: "signac~=1.0.0"
   test-3.8-signac-1.3:
     <<: *test-template
     environment:
-      SIGNAC_VERSION: "~=1.3.0"
+      SIGNAC_VERSION: "signac~=1.3.0"
   test-3.8-signac-1.4:
     <<: *test-template
     environment:
-      SIGNAC_VERSION: "~=1.4.0"
+      SIGNAC_VERSION: "signac~=1.4.0"
+  test-3.8-signac-latest:
+    <<: *test-template
+    environment:
+      SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
   test-3.7:
     <<: *test-template
     docker:
@@ -154,6 +158,16 @@ workflows:
             - test-3.8-signac-1.0
             - test-3.8-signac-1.3
             - test-3.8-signac-1.4
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test-3.8-signac-latest
   deploy:
     jobs:
       - deploy-pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ workflows:
             - test-3.8-signac-1.0
             - test-3.8-signac-1.3
             - test-3.8-signac-1.4
+            - test-3.8-signac-latest
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
## Description
Adds a nightly CI configuration.

## Motivation and Context
Running nightly CI means we can catch issues resulting from changes in signac without those errors causing problems for new pull requests to signac-flow. Finishes work discussed on #345.

## Types of Changes
- [x] CI

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
