### PR TITLE
Fix inconsistant commandline arguments name.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -3720,8 +3720,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         self.submit(jobs=jobs, names=names, **kwargs)
 
     def _main_exec(self, args):
-        if len(args.jobid):
-            jobs = [self.open_job(id=jid) for jid in args.jobid]
+        if len(args.job_id):
+            jobs = [self.open_job(id=jid) for jid in args.job_id]
         else:
             jobs = self
         try:
@@ -3940,7 +3940,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             choices=list(sorted(self._operations)),
             help="The operation to execute.")
         parser_exec.add_argument(
-            'jobid',
+            'job_id',
             type=str,
             nargs='*',
             help="The job ids, as registered in the signac project. "


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Fixes inconsistent argument names in our command line API (in `exec`).
This relates to a positional argument, so I wouldn't consider this a breaking change.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
