### PR TITLE
Upgrade pre-commit and CI config, remove pytest-subtests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,19 +150,19 @@ workflows:
   version: 2
   test:
     jobs:
-      - pre-test-checks
+      - pre-checks
       - linux-python-39:
           requires:
-            - pre-test-checks
+            - pre-checks
       - linux-python-38:
           requires:
-            - pre-test-checks
+            - pre-checks
       - linux-python-37:
           requires:
-            - pre-test-checks
+            - pre-checks
       - linux-python-36:
           requires:
-            - pre-test-checks
+            - pre-checks
       - linux-python-39-signac-10:
           requires:
             - linux-python-39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,15 +75,15 @@ jobs:
           path: test-reports
           destination: test-reports
 
-  linux-python-39-signac-1.0:
+  linux-python-39-signac-10:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.0.0"
-  linux-python-39-signac-1.3:
+  linux-python-39-signac-13:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.3.0"
-  linux-python-39-signac-1.4:
+  linux-python-39-signac-14:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.4.0"
@@ -163,13 +163,13 @@ workflows:
       - linux-python-36:
           requires:
             - pre-test-checks
-      - linux-python-39-signac-1.0:
+      - linux-python-39-signac-10:
           requires:
             - linux-python-39
-      - linux-python-39-signac-1.3:
+      - linux-python-39-signac-13:
           requires:
             - linux-python-39
-      - linux-python-39-signac-1.4:
+      - linux-python-39-signac-14:
           requires:
             - linux-python-39
       - check-metadata:
@@ -185,9 +185,9 @@ workflows:
             - linux-python-38
             - linux-python-37
             - linux-python-36
-            - linux-python-39-signac-1.0
-            - linux-python-39-signac-1.3
-            - linux-python-39-signac-1.4
+            - linux-python-39-signac-10
+            - linux-python-39-signac-13
+            - linux-python-39-signac-14
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,59 @@
-# Python CircleCI 2.0 configuration file
+# CircleCI configuration file
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: 2.1
+
+references:
+  restore_keys: &restore_keys
+    keys:
+      - python-env-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-test.txt" }}-{{ checksum "requirements-precommit.txt" }}-{{ checksum ".pre-commit-config.yaml" }}
+
+  save_key: &save_key
+    key: python-env-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements-test.txt" }}-{{ checksum "requirements-precommit.txt" }}-{{ checksum ".pre-commit-config.yaml" }}
 
 jobs:
-  check-metadata:
+  pre-checks:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
 
     working_directory: ~/repo
 
     steps:
       - checkout
-      - run:
-          name: install-dev-requirements
-          command: |
-            pip install --user -U -r requirements-test.txt
-      - run:
-          name: check-citation-metadata
-          command: |
-            ./.sync-zenodo-metadata.py --check > /dev/null
 
-  pre-test-checks:
-    docker:
-      - image: circleci/python:3.8
+      - restore_cache:
+          <<: *restore_keys
 
-    working_directory: ~/repo
-
-    steps:
-      - checkout
       - run:
-          name: install-dev-requirements
+          name: Install pre-check dependencies
           command: |
-            pip install --user -U -r requirements-precommit.txt
+            pip install --progress-bar off --user -U -r requirements-precommit.txt
+
       - run:
           name: Run pre-checks
           command: |
-            pre-commit run --all-files
+            PRE_COMMIT_HOME=.pre-commit-cache pre-commit run --all-files --show-diff-on-failure
 
-  test-3.8: &test-template
+      - save_cache:
+          <<: *save_key
+          paths:
+            - ".pre-commit-cache"
+
+
+  linux-python-39: &test-template
     environment:
       SIGNAC_VERSION: "signac"
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
 
     working_directory: ~/repo
 
     steps:
       - checkout
+
       - run:
-          name: install dependencies
+          name: Install dependencies
           command: |
             pip install -U virtualenv --user
             mkdir -p ./venv
@@ -72,34 +75,57 @@ jobs:
           path: test-reports
           destination: test-reports
 
-  test-3.8-signac-1.0:
+  linux-python-39-signac-1.0:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.0.0"
-  test-3.8-signac-1.3:
+  linux-python-39-signac-1.3:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.3.0"
-  test-3.8-signac-1.4:
+  linux-python-39-signac-1.4:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "signac~=1.4.0"
-  test-3.8-signac-latest:
+  linux-python-39-signac-latest:
     <<: *test-template
     environment:
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
-  test-3.7:
+  linux-python-38:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.8
+  linux-python-37:
     <<: *test-template
     docker:
       - image: circleci/python:3.7
-  test-3.6:
+  linux-python-36:
     <<: *test-template
     docker:
       - image: circleci/python:3.6
 
+  check-metadata:
+    docker:
+      - image: circleci/python:3.9
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: install-dev-requirements
+          command: |
+            pip install --user -U -r requirements-test.txt
+
+      - run:
+          name: check-citation-metadata
+          command: |
+            ./.sync-zenodo-metadata.py --check > /dev/null
+
   test-deploy-pypi:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
     working_directory: ~/repo
     steps:
       - checkout
@@ -110,7 +136,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
     working_directory: ~/repo
     steps:
       - checkout
@@ -122,42 +148,46 @@ jobs:
 
 workflows:
   version: 2
-  pre-test-checks-and-tests:
+  test:
     jobs:
+      - pre-test-checks
+      - linux-python-39:
+          requires:
+            - pre-test-checks
+      - linux-python-38:
+          requires:
+            - pre-test-checks
+      - linux-python-37:
+          requires:
+            - pre-test-checks
+      - linux-python-36:
+          requires:
+            - pre-test-checks
+      - linux-python-39-signac-1.0:
+          requires:
+            - linux-python-39
+      - linux-python-39-signac-1.3:
+          requires:
+            - linux-python-39
+      - linux-python-39-signac-1.4:
+          requires:
+            - linux-python-39
       - check-metadata:
           filters:
             branches:
               only: /release\/.*/
-      - pre-test-checks
-      - test-3.6:
-          requires:
-            - pre-test-checks
-      - test-3.7:
-          requires:
-            - pre-test-checks
-      - test-3.8:
-          requires:
-            - pre-test-checks
-      - test-3.8-signac-1.0:
-          requires:
-            - test-3.8
-      - test-3.8-signac-1.3:
-          requires:
-            - test-3.8
-      - test-3.8-signac-1.4:
-          requires:
-            - test-3.8
       - test-deploy-pypi:
           filters:
             branches:
               only: /release\/.*/
           requires:
-            - test-3.6
-            - test-3.7
-            - test-3.8
-            - test-3.8-signac-1.0
-            - test-3.8-signac-1.3
-            - test-3.8-signac-1.4
+            - linux-python-39
+            - linux-python-38
+            - linux-python-37
+            - linux-python-36
+            - linux-python-39-signac-1.0
+            - linux-python-39-signac-1.3
+            - linux-python-39-signac-1.4
   nightly:
     triggers:
       - schedule:
@@ -167,7 +197,7 @@ workflows:
               only:
                 - master
     jobs:
-      - test-3.8-signac-latest
+      - linux-python-39-signac-latest
   deploy:
     jobs:
       - deploy-pypi:

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,9 @@ pip-log.txt
 .noseids
 .coverage
 .tox
+.mypy_cache
 nosetests.xml
+.pytest_cache
 
 # Translations
 *.mo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,40 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: ''
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v3.3.0'
     hooks:
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
         exclude: 'setup.cfg'
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
         exclude: 'setup.cfg'
-    -   id: debug-statements
--   repo: local
+      - id: debug-statements
+  - repo: https://github.com/asottile/pyupgrade
+    rev: 'v2.7.3'
     hooks:
-    -   id: flake8
-        name: flake8
-        entry: flake8
-        language: python
-        types: [python]
-    -   id: pydocstyle
-        name: pydocstyle
-        entry: pydocstyle
-        language: python
-        types: [python]
+      - id: pyupgrade
+        exclude: '(?:mistune/.*)'
+        args:
+          - --py36-plus
+  - repo: https://github.com/pycqa/isort
+    rev: '5.6.4'
+    hooks:
+      - id: isort
+        exclude: '(?:mistune/.*)'
+  - repo: https://github.com/psf/black
+    rev: '20.8b1'
+    hooks:
+      - id: black
+        exclude: '(?:mistune/.*)'
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: '3.8.4'
+    hooks:
+      - id: flake8
+        exclude: '(?:mistune/.*)'
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: '5.1.1'
+    hooks:
+      - id: pydocstyle
+        files: ^((?!doc|tests|mistune).)*$
+# - repo: https://github.com/pre-commit/mirrors-mypy
+#   rev: 'v0.790'
+#   hooks:
+#     - id: mypy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,7 @@ Please see the [Support](https://docs.signac.io/projects/signac-core/en/latest/s
 
 ### Code Style
 
-Code must adhere to the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) with the exception that lines may have up to 100 characters.
-
-We recommend to use [flake8](http://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/) to find and fix any code style issues prior to committing and pushing.
+The [pre-commit tool](https://pre-commit.com/) is used to enforce code style guidelines. Use `pip install pre-commit` to install the tool and `pre-commit install` to configure pre-commit hooks.
 
 ## Reviewing Pull Requests
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Version 0.12
 Added
 +++++
 - Code is formatted with ``black`` and ``isort`` pre-commit hooks (#365).
+- Add official support for Python version 3.9 (#365).
 
 Changed
 +++++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,21 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.12
+============
+
+[0.12.0] -- 202x-xx-xx
+----------------------
+
+Added
++++++
+- Code is formatted with ``black`` and ``isort`` pre-commit hooks (#365).
+
+Changed
++++++++
+- Command line interface for ``exec`` changed parameter name from ``jobid`` to ``job_id`` (#363).
+
+
 Version 0.11
 ============
 

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -35,14 +35,14 @@ for example with `venv <https://docs.python.org/3/library/venv.html>`_:
 
     ~ $ python -m venv ~/envs/signac-flow-dev
     ~ $ source ~/envs/signac-flow-dev/bin/activate
-    (signac-flow-dev) ~ $ pip install -r requirements-dev.txt
+    (signac-flow-dev) ~ $ pip install -r requirements-dev.txt -r requirements-precommit.txt
 
 or alternatively with `conda <https://conda.io/docs/>`_:
 
 .. code-block:: bash
 
-    ~ $ conda create -n signac-flow-dev python --file requirements-dev.txt
-    ~ $ activate signac-flow-dev
+    ~ $ conda create -n signac-flow-dev python --file requirements-dev.txt --file requirements-precommit.txt
+    ~ $ conda activate signac-flow-dev
 
 Then clone your fork and install the package from source with:
 
@@ -54,14 +54,15 @@ Then clone your fork and install the package from source with:
 The ``-e`` option stands for *editable*, which means that the package is directly loaded from the source code repository.
 That means any changes made to the source code are immediately reflected upon reloading the Python interpreter.
 
-Finally, we recommend to setup a `Flake8 <http://flake8.pycqa.org/en/latest/>`_ git commit hook with:
+The `pre-commit tool <https://pre-commit.com/>`__ is used to enforce code style guidelines.
+To install the tool and configure pre-commit hooks, execute:
 
 .. code-block:: bash
 
-    (signac-flow-dev) signac-flow $ flake8 --install-hook git
-    (signac-flow-dev) signac-flow $ git config --bool flake8.strict true
+    (signac-flow-dev) signac $ pip install pre-commit
+    (signac-flow-dev) signac $ pre-commit install
 
-With the *flake8* hook, your code will be checked for syntax and style before you make a commit.
+With the pre-commit hook, your code will be checked for syntax and style before you make a commit.
 The continuous integration pipeline for the package will perform these checks as well, so running these tests before committing / pushing will prevent the pipeline from failing due to style-related issues.
 
 The development workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.black]
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | build
+    | dist
+    | signac/common/configobj/.*
+  )/
+)
+'''
+
+[tool.isort]
+profile = 'black'
+skip_glob = 'signac/common/configobj/*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ exclude = '''
     | \.venv
     | build
     | dist
-    | signac/common/configobj/.*
+    | flow/util/mistune
   )/
 )
 '''
 
 [tool.isort]
 profile = 'black'
-skip_glob = 'signac/common/configobj/*'
+skip_glob = 'flow/util/mistune/*'

--- a/requirements-precommit.txt
+++ b/requirements-precommit.txt
@@ -1,3 +1,1 @@
-flake8==3.8.4
 pre-commit==2.8.2
-pydocstyle==5.1.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 click==7.1.2
 ruamel.yaml==0.16.12
-pytest>=4.4, <6.0
-pytest-subtests
+pytest==6.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ match = template_filters.py
 
 [flake8]
 max-line-length = 100
-exclude = mistune,doc/conf.py
+exclude = mistune
 # Use select to ignore unwanted flake8 plugins
 select = E,F,W
 # Specify errors to ignore by default
@@ -32,6 +32,6 @@ ignore = E123,E126,E226,E241,E704,W503,W504
 [bumpversion:file:.zenodo.json]
 
 [tool:pytest]
-filterwarnings = 
+filterwarnings =
 	ignore:.*get_id is deprecated.*:DeprecationWarning
 	ignore:.*The env argument is deprecated*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Description
Updates pre-commit to use black, isort, etc. This is nearly the same set of changes as https://github.com/glotzerlab/signac/pull/415.

**The updated files with these pre-commit hooks applied will be merged in #366. Tests will not pass on this PR, but should pass on #366.**

I think this will be extremely helpful as we begin to refactor the codebase. Hopefully this will allow us to skip over most style-related PR comments that tend to drag PRs down.

I also removed the dependency on pytest-subtests, which was only used in one place (and was holding back our pinning of pytest as a testing dependency).

Lastly, I added official Python 3.9 support. Python 3.9 is now in the test matrix.

## Motivation and Context
1. The development team decided to adopt `black` as a code formatter at the previous developer meeting. I hope this will make the process of development faster as a whole. While there is a nonzero cost to having a pre-commit workflow with many hooks, it is worth it if this kind of change can reduce the number of iterations and "nitpick" style comments needed during PR review.

2. Consolidating pre-commit hooks (and not using local hooks) will make it easier to install and manage linters/fixers.

## Types of Changes
- [x] New feature

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
