### PR TITLE
from tqdm.auto import tqdm

### DIFF
--- a/flow/operations.py
+++ b/flow/operations.py
@@ -15,7 +15,7 @@ from functools import wraps
 from multiprocessing import Pool
 
 from signac import get_project
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -37,7 +37,7 @@ from jinja2 import TemplateNotFound as Jinja2TemplateNotFound
 from signac.contrib.filterparse import parse_filter_arg
 from signac.contrib.hashing import calc_id
 from signac.contrib.project import JobsCursor
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .aggregates import _DefaultAggregateStore, aggregator, get_aggregate_id
 from .environment import get_environment

--- a/flow/render_status.py
+++ b/flow/render_status.py
@@ -1,5 +1,5 @@
 # make separate python class for render_status
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .scheduling.base import JobStatus
 from .util import mistune


### PR DESCRIPTION
## Description
This small PR uses tqdm.auto for better notebook compatibility.

From the tqdm README:
```python
class tqdm.auto.tqdm(tqdm.tqdm):
    """Automatically chooses beween `tqdm.notebook` and `tqdm.tqdm`."""
```

## Motivation and Context
Makes signac-flow processes that use tqdm prettier in notebooks.
I verified that our requirement of tqdm >=4.35 is sufficient for this feature.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
