### PR TITLE
Remove dangling else/elif clauses after raise/return statements.

### DIFF
--- a/flow/directives.py
+++ b/flow/directives.py
@@ -99,8 +99,7 @@ class _Directive:
                 return self._validator(value(*jobs))
 
             return validate_callable
-        else:
-            return self._validator(value)
+        return self._validator(value)
 
 
 class _Directives(MutableMapping):
@@ -131,11 +130,10 @@ class _Directives(MutableMapping):
             raise TypeError(
                 f"Expected a _Directive object. Received {type(directive)}."
             )
-        elif directive._name in self._directive_definitions:
+        if directive._name in self._directive_definitions:
             raise ValueError(f"Cannot redefine directive name {directive._name}.")
-        else:
-            self._directive_definitions[directive._name] = directive
-            self._defined_directives[directive._name] = directive._default
+        self._directive_definitions[directive._name] = directive
+        self._defined_directives[directive._name] = directive._default
 
     def _set_defined_directive(self, key, value):
         try:
@@ -147,10 +145,9 @@ class _Directives(MutableMapping):
         if key in self._defined_directives and key in self._directive_definitions:
             value = self._defined_directives[key]
             return self._directive_definitions[key]._finalize(value, self)
-        elif key in self._user_directives:
+        if key in self._user_directives:
             return self._user_directives[key]
-        else:
-            raise KeyError(f"{key} not in directives.")
+        raise KeyError(f"{key} not in directives.")
 
     def __setitem__(self, key, value):
         if key in self._directive_definitions:
@@ -206,10 +203,8 @@ def _evaluate(value, jobs):
             raise RuntimeError(
                 "jobs must be specified when evaluating a callable directive."
             )
-        else:
-            return value(*jobs)
-    else:
-        return value
+        return value(*jobs)
+    return value
 
 
 class _OnlyType:
@@ -269,8 +264,7 @@ def _finalize_np(np, directives):
     omp_num_threads = directives.get("omp_num_threads", 1)
     if callable(nranks) or callable(omp_num_threads):
         return np
-    else:
-        return max(np, max(1, nranks) * max(1, omp_num_threads))
+    return max(np, max(1, nranks) * max(1, omp_num_threads))
 
 
 # Helper validators for defining _Directive
@@ -281,8 +275,7 @@ def _no_aggregation(v, o):
 def _is_fraction(value):
     if 0 <= value <= 1:
         return value
-    else:
-        raise ValueError("Value must be between 0 and 1.")
+    raise ValueError("Value must be between 0 and 1.")
 
 
 _natural_number = _OnlyType(int, postprocess=_raise_below(1))

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -88,7 +88,7 @@ class ComputeEnvironmentType(type):
             cls.registry = OrderedDict()
         else:
             cls.registry[name] = cls
-        return super().__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
 
 def template_filter(func):
@@ -127,10 +127,8 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
         if cls.hostname_pattern is None:
             if cls.scheduler_type is None:
                 return False
-            else:
-                return cls.scheduler_type.is_present()
-        else:
-            return re.match(cls.hostname_pattern, socket.getfqdn()) is not None
+            return cls.scheduler_type.is_present()
+        return re.match(cls.hostname_pattern, socket.getfqdn()) is not None
 
     @classmethod
     def get_scheduler(cls):
@@ -165,6 +163,7 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
         # Hand off the actual submission to the scheduler
         if cls.get_scheduler().submit(script, flags=flags, *args, **kwargs):
             return JobStatus.submitted
+        return None
 
     @classmethod
     def add_args(cls, parser):
@@ -235,8 +234,7 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
         """
         if operation.directives.get("nranks"):
             return "{} -n {} ".format(cls.mpi_cmd, operation.directives["nranks"])
-        else:
-            return ""
+        return ""
 
     @template_filter
     def get_prefix(cls, operation, parallel=False, mpi_prefix=None, cmd_prefix=None):
@@ -473,35 +471,34 @@ def get_environment(test=False, import_configured=True):
     """
     if test:
         return TestEnvironment
-    else:
-        # Obtain a list of all registered environments
-        env_types = registered_environments(import_configured=import_configured)
-        logger.debug(
-            "List of registered environments:\n\t{}".format(
-                "\n\t".join(str(env.__name__) for env in env_types)
-            )
+
+    # Obtain a list of all registered environments
+    env_types = registered_environments(import_configured=import_configured)
+    logger.debug(
+        "List of registered environments:\n\t{}".format(
+            "\n\t".join(str(env.__name__) for env in env_types)
         )
+    )
 
-        # Select environment based on environment variable if set.
-        env_from_env_var = os.environ.get("SIGNAC_FLOW_ENVIRONMENT")
-        if env_from_env_var:
-            for env_type in env_types:
-                if env_type.__name__ == env_from_env_var:
-                    return env_type
-            else:
-                raise ValueError(f"Unknown environment '{env_from_env_var}'.")
-
-        # Select based on DEBUG flag:
+    # Select environment based on environment variable if set.
+    env_from_env_var = os.environ.get("SIGNAC_FLOW_ENVIRONMENT")
+    if env_from_env_var:
         for env_type in env_types:
-            if getattr(env_type, "DEBUG", False):
-                logger.debug(f"Select environment '{env_type.__name__}'; DEBUG=True.")
+            if env_type.__name__ == env_from_env_var:
                 return env_type
+        raise ValueError(f"Unknown environment '{env_from_env_var}'.")
 
-        # Default selection:
-        for env_type in reversed(env_types):
-            if env_type.is_present():
-                logger.debug(f"Select environment '{env_type.__name__}'; is present.")
-                return env_type
+    # Select based on DEBUG flag:
+    for env_type in env_types:
+        if getattr(env_type, "DEBUG", False):
+            logger.debug(f"Select environment '{env_type.__name__}'; DEBUG=True.")
+            return env_type
 
-        # Otherwise, just return a standard environment
-        return StandardEnvironment
+    # Default selection:
+    for env_type in reversed(env_types):
+        if env_type.is_present():
+            logger.debug(f"Select environment '{env_type.__name__}'; is present.")
+            return env_type
+
+    # Otherwise, just return a standard environment
+    return StandardEnvironment

--- a/flow/project.py
+++ b/flow/project.py
@@ -341,8 +341,7 @@ class _JobOperation:
             # error, but not until then. If we don't fork then nothing errors,
             # and the user gets the expected result.
             return self._cmd()
-        else:
-            return self._cmd
+        return self._cmd
 
     def set_status(self, value):
         "Store the operation's status."
@@ -684,8 +683,7 @@ class FlowCmdOperation(BaseFlowOperation):
 
         if callable(self._cmd):
             return self._cmd(job).format(job=job)
-        else:
-            return self._cmd.format(job=job)
+        return self._cmd.format(job=job)
 
 
 class FlowOperation(BaseFlowOperation):
@@ -755,8 +753,7 @@ class FlowGroupEntry:
                     "Cannot register existing name {} with group {}"
                     "".format(func, self.name)
                 )
-            else:
-                func._flow_groups.append(self.name)
+            func._flow_groups.append(self.name)
         else:
             func._flow_groups = [self.name]
         return func
@@ -768,8 +765,7 @@ class FlowGroupEntry:
                     "Cannot set directives because directives already exist for {} "
                     "in group {}".format(func, self.name)
                 )
-            else:
-                func._flow_group_operation_directives[self.name] = directives
+            func._flow_group_operation_directives[self.name] = directives
         else:
             func._flow_group_operation_directives = {self.name: directives}
 
@@ -904,17 +900,13 @@ class FlowGroup:
         cmd = cmd if self.options is None else cmd + " " + self.options
         if ignore_conditions != IgnoreConditions.NONE:
             return cmd.strip() + " --ignore-conditions=" + str(ignore_conditions)
-        else:
-            return cmd.strip()
+        return cmd.strip()
 
     def _run_cmd(self, entrypoint, operation_name, operation, directives, jobs):
         if isinstance(operation, FlowCmdOperation):
             return operation(*jobs).lstrip()
-        else:
-            entrypoint = self._determine_entrypoint(entrypoint, directives, jobs)
-            return (
-                f"{entrypoint} exec {operation_name} {get_aggregate_id(jobs)}".lstrip()
-            )
+        entrypoint = self._determine_entrypoint(entrypoint, directives, jobs)
+        return f"{entrypoint} exec {operation_name} {get_aggregate_id(jobs)}".lstrip()
 
     def __iter__(self):
         yield from self.operations.values()
@@ -3280,8 +3272,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                             )
                         aggregates.add(aggregate)  # An aggregate provided by the user
             return list(aggregates)
-        else:
-            return None
+        return None
 
     @contextlib.contextmanager
     def _potentially_buffered(self):
@@ -4276,8 +4267,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         """
         if name in cls._GROUP_NAMES:
             raise ValueError(f"Repeat definition of group with name '{name}'.")
-        else:
-            cls._GROUP_NAMES.add(name)
+        cls._GROUP_NAMES.add(name)
         group_entry = FlowGroupEntry(name, options, aggregator.groupsof(1))
         cls._GROUPS.append(group_entry)
         return group_entry
@@ -4905,6 +4895,7 @@ def _serializer(loads, root, *args):
         groups_aggregate = loads(args[4])
         project._stored_aggregates = groups_aggregate
         return project._get_group_status(group, ignore_errors, cached_status)
+    return None
 
 
 # Status-related helper functions


### PR DESCRIPTION
## Description
This PR removes dangling else/elif clauses after raise/return statements.
By making this change, the indentation level is reduced, the code is simpler to read, and methods are more likely to hit a return statement rather than implicitly returning None (which reduces the likelihood of bugs).

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
