### PR TITLE
Remove unused attributes/methods.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -1327,9 +1327,6 @@ class _FlowProjectClass(type):
 
             _parent_class = parent_class
 
-            def __init__(self, condition, tag=None):
-                super().__init__(condition, tag)
-
             def __call__(self, func):
                 operation_functions = [
                     operation[1]
@@ -1398,9 +1395,6 @@ class _FlowProjectClass(type):
             """
 
             _parent_class = parent_class
-
-            def __init__(self, condition, tag=None):
-                super().__init__(condition, tag)
 
             def __call__(self, func):
                 operation_functions = [

--- a/flow/project.py
+++ b/flow/project.py
@@ -3782,8 +3782,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         )
 
     @classmethod
-    def _add_operation_selection_arg_group(cls, parser, operations=None):
-        "Add argument group to parser for job-operation selection."
+    def _add_operation_selection_arg_group(cls, parser):
+        """Add argument group to parser for job-operation selection."""
         selection_group = parser.add_argument_group(
             "job-operation selection",
             "By default, all eligible operations for all jobs are selected. Use "
@@ -4651,9 +4651,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             "run",
             parents=[base_parser],
         )
-        self._add_operation_selection_arg_group(
-            parser_run, list(sorted(self._operations))
-        )
+        self._add_operation_selection_arg_group(parser_run)
 
         execution_group = parser_run.add_argument_group("execution")
         execution_group.add_argument(

--- a/flow/project.py
+++ b/flow/project.py
@@ -439,7 +439,7 @@ class JobOperation(_JobOperation):
         return "{type}(name='{name}', job='{job}', cmd={cmd}, directives={directives})".format(
             type=type(self).__name__,
             name=self.name,
-            job=repr(self._jobs[0]),
+            job=repr(self.job),
             cmd=repr(self.cmd),
             directives=self.directives,
         )

--- a/flow/project.py
+++ b/flow/project.py
@@ -4359,7 +4359,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         "Print status overview."
         aggregates = self._select_jobs_from_args(args)
         if args.compact and not args.unroll:
-            logger.warn(
+            logger.warning(
                 "The -1/--one-line argument is incompatible with "
                 "'--stack' and will be ignored."
             )

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -30,7 +30,7 @@ def _fetch(user=None):
         return tree.getroot()
     except ET.ParseError as error:
         if str(error) == "no element found: line 1, column 0":
-            logger.warn(
+            logger.warning(
                 "No scheduler jobs, from any user(s), were detected. "
                 "This may be the result of a misconfiguration in the "
                 "environment."


### PR DESCRIPTION
## Description
This PR removes some unused arguments/methods and performs a couple other small edits that didn't fit into other PRs.

- Remove unused `__init__` from pre/post conditions classes, because the implicit parent constructor is equivalent.
- Remove unused argument from `_add_operation_selection_arg_group`. At one point, `python project.py run --help` would show the list of operations that a user could supply to the `-o` flag. That was added in 0aa28b5b02acf733ac6604c2d68a73972ae116eb but I couldn't find exactly when it was removed. I would guess it was some time around the introduction of groups, since groups are also valid choices for `-o` and that behavior change might have been the cause for the removal of the feature.
- Use public `self.job` property instead of private data in deprecated class `JobOperation`'s `__repr__` method.
- Use `logger.warning` instead of the deprecated method `logger.warn`.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
