### PR TITLE
Deprecate CPUEnvironment and GPUEnvironment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,7 +19,7 @@ Added
 Changed
 +++++++
 - Command line interface for ``exec`` changed parameter name from ``jobid`` to ``job_id`` (#363).
-
+- ``CPUEnvironment`` and ``GPUEnvironment`` classes are deprecated (#381).
 
 Version 0.11
 ============

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -17,6 +17,7 @@ import re
 import socket
 from collections import OrderedDict
 
+from deprecation import deprecated
 from signac.common import config
 
 from .directives import (
@@ -37,6 +38,7 @@ from .scheduling.simple_scheduler import SimpleScheduler
 from .scheduling.slurm import SlurmScheduler
 from .scheduling.torque import TorqueScheduler
 from .util import config as flow_config
+from .version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -418,11 +420,13 @@ class DefaultLSFEnvironment(NodesEnvironment, LSFEnvironment):
         )
 
 
+@deprecated(deprecated_in="0.12", removed_in="0.14", current_version=__version__)
 class CPUEnvironment(ComputeEnvironment):
     "An environment with CPUs."
     pass
 
 
+@deprecated(deprecated_in="0.12", removed_in="0.14", current_version=__version__)
 class GPUEnvironment(ComputeEnvironment):
     "An environment with GPUs."
     pass

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -10,7 +10,6 @@ This enables the user to adjust their workflow based on the present
 environment, e.g. for the adjustment of scheduler submission scripts.
 """
 import importlib
-import importlib.machinery
 import logging
 import os
 import re
@@ -430,16 +429,6 @@ class CPUEnvironment(ComputeEnvironment):
 class GPUEnvironment(ComputeEnvironment):
     "An environment with GPUs."
     pass
-
-
-def _import_module(fn):
-    return importlib.machinery.SourceFileLoader(fn, fn).load_module()
-
-
-def _import_modules(prefix):
-    for fn in os.path.listdir(prefix):
-        if os.path.isfile(fn) and os.path.splitext(fn)[1] == ".py":
-            _import_module(os.path.join(prefix, fn))
 
 
 def _import_configured_environments():


### PR DESCRIPTION
## Description
This PR deprecates CPUEnvironment and GPUEnvironment. The classes are unused and untested.
I also removed two unused private functions for importing environments from files.

## Types of Changes
- [x] Deprecation/removal
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
