### PR TITLE
Fix group name check

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -4048,13 +4048,13 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         :type pre:
             sequence of callables
         """
-        if name in self.operations:
-            raise KeyError("An operation with this identifier is already added.")
-        op = self.operations[name] = FlowCmdOperation(cmd=cmd, pre=pre, post=post)
-        if name in self._groups:
-            raise KeyError("A group with this identifier already exists.")
+        if name in self.operations or name in self._groups:
+            raise KeyError("An operation or group with this name already exists.")
+        operation = self.operations[name] = FlowCmdOperation(
+            cmd=cmd, pre=pre, post=post
+        )
         self._groups[name] = FlowGroup(
-            name, operations={name: op}, operation_directives=dict(name=kwargs)
+            name, operations={name: operation}, operation_directives=dict(name=kwargs)
         )
 
     def completed_operations(self, job):

--- a/flow/project.py
+++ b/flow/project.py
@@ -4128,7 +4128,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
     def add_operation(self, name, cmd, pre=None, post=None, **kwargs):
         """Add an operation to the workflow.
 
-        This method will add an instance of :py:class:`~.FlowOperation` to the
+        This method will add an instance of :py:class:`~.FlowCmdOperation` to the
         operations of this project.
 
         .. seealso::
@@ -4136,27 +4136,28 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             A Python function may be defined as an operation function directly using
             the :meth:`~.operation` decorator.
 
-        Any FlowOperation is associated with a specific command, which should be
-        a function of :py:class:`~signac.contrib.job.Job`. The command (cmd) can
-        be stated as function, either by using str-substitution based on a job's
-        attributes, or by providing a unary callable, which expects an instance
-        of job as its first and only positional argument.
+        A FlowCmdOperation is associated with a specific command, which
+        should be a function of :py:class:`~signac.contrib.job.Job`. The
+        command (cmd) can be stated as a function, either by using string
+        substitution based on a job's attributes, or by providing a unary
+        callable, which expects an instance of job as its first and only
+        positional argument.
 
-        For example, if we wanted to define a command for a program called 'hello',
-        which expects a job id as its first argument, we could construct the following
-        two equivalent operations:
+        For example, if we wanted to define a command for a program called
+        'hello', which expects a job id as its first argument, we could
+        construct the following two equivalent operations:
 
         .. code-block:: python
 
-            op = FlowOperation('hello', cmd='hello {job._id}')
-            op = FlowOperation('hello', cmd=lambda 'hello {}'.format(job._id))
+            op = FlowCmdOperation('hello', cmd='hello {job._id}')
+            op = FlowCmdOperation('hello', cmd=lambda 'hello {}'.format(job._id))
 
         Here are some more useful examples for str-substitutions:
 
         .. code-block:: python
 
             # Substitute job state point parameters:
-            op = FlowOperation('hello', cmd='cd {job.ws}; hello {job.sp.a}')
+            op = FlowCmdOperation('hello', cmd='cd {job.ws}; hello {job.sp.a}')
 
         Pre-conditions (pre) and post-conditions (post) can be used to
         trigger an operation only when certain conditions are met. Conditions are unary
@@ -4191,9 +4192,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         """
         if name in self.operations or name in self._groups:
             raise KeyError("An operation or group with this name already exists.")
-        operation = self.operations[name] = FlowCmdOperation(
-            cmd=cmd, pre=pre, post=post
-        )
+        operation = FlowCmdOperation(cmd=cmd, pre=pre, post=post)
+        self.operations[name] = operation
         self._groups[name] = FlowGroup(
             name, operations={name: operation}, operation_directives=dict(name=kwargs)
         )


### PR DESCRIPTION
## Description
I noticed a potential issue in `add_operation`. It looks like an operation can be added via `add_operation` that can introduce a conflict with an identical group name. I'd like to get input from @b-butler on this PR before seeking general review.

If this is indeed an issue, I will add a corresponding test.

Also, I'm a bit confused by the usage of `name in self._groups` when there's also a `cls._GROUP_NAMES` attribute. I would appreciate any insight on this from @b-butler or others, since it seems like the two might conflict / overlap / duplicate purpose?

## Motivation and Context
Might fix/prevent a bug.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
