### PR TITLE
Use job_id consistently (adds to #363).

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ Added
 
 Changed
 +++++++
-- Command line interface for ``exec`` changed parameter name from ``jobid`` to ``job_id`` (#363).
+- Command line interface always uses ``--job-id`` instead of ``--jobid`` (#363, #386).
 - ``CPUEnvironment`` and ``GPUEnvironment`` classes are deprecated (#381).
 
 Version 0.11

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -200,7 +200,7 @@ def run(parser=None):
         help="The operation to execute.",
     )
     parser.add_argument(
-        "jobid",
+        "job_id",
         type=str,
         nargs="*",
         help="The job ids, as registered in the signac project. "
@@ -238,9 +238,9 @@ def run(parser=None):
         except LookupError:
             raise LookupError(f"Multiple matches for id '{_id}'.")
 
-    if len(args.jobid):
+    if len(args.job_id):
         try:
-            jobs = [_open_job_by_id(jid) for jid in args.jobid]
+            jobs = [_open_job_by_id(jid) for jid in args.job_id]
         except (KeyError, LookupError) as error:
             print(error, file=sys.stderr)
             sys.exit(1)

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -240,7 +240,7 @@ def run(parser=None):
 
     if len(args.job_id):
         try:
-            jobs = [_open_job_by_id(jid) for jid in args.job_id]
+            jobs = [_open_job_by_id(job_id) for job_id in args.job_id]
         except (KeyError, LookupError) as error:
             print(error, file=sys.stderr)
             sys.exit(1)

--- a/flow/project.py
+++ b/flow/project.py
@@ -4599,7 +4599,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 operation_function(*aggregate)
 
     def _select_jobs_from_args(self, args):
-        """Select jobs with the given command line arguments ('-j/-f/--doc-filter/--jobid')."""
+        """Select jobs with the given command line arguments ('-j/-f/--doc-filter/--job-id')."""
         if (
             not args.func == self._main_exec
             and args.job_id

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -25,8 +25,8 @@ class JobStatus(enum.IntEnum):
 class ClusterJob:
     """This class represents a cluster job."""
 
-    def __init__(self, jobid, status=None):
-        self._job_id = jobid
+    def __init__(self, job_id, status=None):
+        self._job_id = job_id
         self._status = status
 
     def _id(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1183,9 +1183,9 @@ class TestProjectMainInterface(TestProjectBase):
 
     def test_main_next(self):
         assert len(self.project)
-        jobids = set(self.call_subcmd("next op1").decode().split())
+        job_ids = set(self.call_subcmd("next op1").decode().split())
         even_jobs = [job.get_id() for job in self.project if job.sp.b % 2 == 0]
-        assert jobids == set(even_jobs)
+        assert job_ids == set(even_jobs)
 
     def test_main_status(self):
         assert len(self.project)


### PR DESCRIPTION
## Description
This changes operations modules and internal variables to match the use of `job_id` instead of `jobid`. This became more standardized in #363 but several more places were overlooked.

## Motivation and Context
Improves consistency of API.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
