### PR TITLE
Add all missing docstrings, enforce pydocstyle.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Added
 +++++
 - Code is formatted with ``black`` and ``isort`` pre-commit hooks (#365).
 - Add official support for Python version 3.9 (#365).
+- Documentation has been added for all public classes and methods (#387).
 
 Changed
 +++++++

--- a/flow/__main__.py
+++ b/flow/__main__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""This module defines the main command line interface for signac-flow.
+"""The main command line interface for signac-flow.
 
 The interface is accessible via the `flow` command and allows users to
 initialize FlowProject class definitions directly from the command line.
@@ -47,7 +47,7 @@ def main_init(args):
 
 
 def main():
-    """Main entry function for the 'flow' command line tool.
+    """Define the 'flow' command line interface.
 
     This function defines the main 'flow' command line interface which can be used
     to initialize FlowProject modules from different templates as well as print the

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -3,8 +3,9 @@
 # This software is licensed under the BSD 3-Clause License.
 """Aggregation allows the definition of operations on multiple jobs.
 
-Operations each have a specific aggregator. The default aggregator uses
-individual jobs from the signac data space.
+Operations are each associated with an aggregator that determines how
+jobs are grouped before being passed as arguments to the operation. The
+default aggregator produces individual jobs.
 """
 import itertools
 from collections.abc import Iterable, Mapping
@@ -12,7 +13,7 @@ from hashlib import md5
 
 
 class aggregator:
-    """Decorator for operation function that is to be aggregated.
+    """Decorator for operation functions that operate on aggregates.
 
     By default, if the ``aggregator_function`` is not passed,
     an aggregate of all jobs will be created.
@@ -78,7 +79,7 @@ class aggregator:
     def groupsof(cls, num=1, sort_by=None, sort_ascending=True, select=None):
         """Aggregate jobs into groupings of a given size.
 
-        By default, aggregates of a single job are created.
+        By default, creates aggregates consisting of a single job.
 
         If the number of jobs present in the project is not divisible by the
         number provided by the user, the last aggregate will be smaller and
@@ -86,7 +87,7 @@ class aggregator:
         project and they are aggregated in groups of 3, then the generated
         aggregates will have lengths 3, 3, 3, and 1.
 
-        The code block below provides an example on how jobs can be aggregated
+        The code block below provides an example of how jobs can be aggregated
         in groups of 2.
 
         .. code-block:: python
@@ -256,9 +257,10 @@ class aggregator:
     def _get_unique_function_id(self, func):
         """Generate unique id for the provided function.
 
-        Hashing the bytecode allows for the comparison of internal functions
-        like ``self._aggregator_function`` or ``self._select`` that may have
-        the same definitions but different hashes.
+        Hashing the bytecode rather than directly hashing the function allows
+        for the comparison of internal functions like ``self._aggregator_function``
+        or ``self._select`` that may have the same definitions but different
+        hashes simply because they are distinct objects.
 
         It is possible for equivalent functions to have different ids if the
         bytecode is not identical.
@@ -308,7 +310,7 @@ class aggregator:
 
 
 class _AggregatesStore(Mapping):
-    """Class containing all aggregates associated with a :class:`aggregator`.
+    """Class containing all aggregates associated with an :class:`aggregator`.
 
     This is a callable class which, when called, generates all the aggregates.
     Iterating over this object yields all aggregates.

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -288,14 +288,22 @@ class aggregator:
             return _AggregatesStore(self, project)
 
     def __call__(self, func=None):
+        """Add this aggregator to a provided operation.
+
+        This call operator allows the class to be used as a decorator.
+
+        :param func:
+            The function to decorate.
+        :type func:
+            callable
+        """
         if callable(func):
             setattr(func, "_flow_aggregate", self)
             return func
         else:
             raise TypeError(
-                "Invalid argument passed while calling "
-                "the aggregate instance. Expected a callable, "
-                f"got {type(func)}."
+                "Invalid argument passed while calling the aggregate "
+                f"instance. Expected a callable, got {type(func)}."
             )
 
 

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -300,8 +300,7 @@ class aggregator:
 
 
 class _AggregatesStore(Mapping):
-    """This class holds the information of all the aggregates associated with
-    a :class:`aggregator`.
+    """Class containing all aggregates associated with a :class:`aggregator`.
 
     This is a callable class which, when called, generates all the aggregates.
     Iterating over this object yields all aggregates.
@@ -338,8 +337,7 @@ class _AggregatesStore(Mapping):
             )
 
     def __contains__(self, id):
-        """Return whether an aggregate is stored in this instance of
-        :py:class:`_AggregateStore`.
+        """Return whether this instance contains an aggregate (by aggregate id).
 
         :param id:
             The id of an aggregate of jobs.
@@ -367,8 +365,9 @@ class _AggregatesStore(Mapping):
         return self._aggregate_per_id.items()
 
     def _register_aggregates(self, project):
-        """If the instance of this class is called then we will
-        generate aggregates and store them in ``self._aggregate_per_id``.
+        """Register aggregates for a given project.
+
+        This is called at instantiation to generate and store aggregates.
         """
         aggregated_jobs = self._generate_aggregates(project)
         self._create_nested_aggregate_list(aggregated_jobs, project)
@@ -418,8 +417,10 @@ class _AggregatesStore(Mapping):
 
 
 class _DefaultAggregateStore(Mapping):
-    """This class holds the information of the project associated with
-    an operation function using the default aggregator, i.e.
+    """Aggregate storage wrapper for the default aggregator.
+
+    This class holds the information of the project associated with an
+    operation function using the default aggregator, i.e.
     ``aggregator.groupsof(1)``.
 
     Iterating over this object yields tuples each containing one job from the project.
@@ -445,8 +446,7 @@ class _DefaultAggregateStore(Mapping):
             raise LookupError(f"Did not find aggregate with id {id}.")
 
     def __contains__(self, id):
-        """Return whether the job is present in the project associated with this
-        instance of :py:class:`_DefaultAggregateStore`.
+        """Return whether this instance contains a job (by job id).
 
         :param id:
             The job id.
@@ -484,9 +484,10 @@ class _DefaultAggregateStore(Mapping):
             yield (job.get_id(), (job,))
 
     def _register_aggregates(self, project):
-        """We have to store self._project when this method is invoked
-        This is because we will then iterate over that project in
-        order to return an aggregates of one.
+        """Register aggregates for a given project.
+
+        A reference to the project is stored on instantiation, and iterated
+        over on-the-fly.
         """
         self._project = project
 

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -1,13 +1,19 @@
 # Copyright (c) 2020 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+"""Aggregation allows the definition of operations on multiple jobs.
+
+Operations each have a specific aggregator. The default aggregator uses
+individual jobs from the signac data space.
+"""
 import itertools
 from collections.abc import Iterable, Mapping
 from hashlib import md5
 
 
 class aggregator:
-    r"""Decorator for operation function that is to be aggregated.
+    """Decorator for operation function that is to be aggregated.
+
     By default, if the ``aggregator_function`` is not passed,
     an aggregate of all jobs will be created.
 
@@ -35,8 +41,8 @@ class aggregator:
     :type sort_ascending:
         bool
     :param select:
-        Condition for filtering individual jobs. This is passed as the
-        callable argument to `filter`. The default behavior is no filtering.
+        Condition for filtering individual jobs. This is passed as the callable
+        argument to :meth:`filter`. The default behavior is no filtering.
     :type select:
         callable or NoneType
     """
@@ -70,18 +76,18 @@ class aggregator:
 
     @classmethod
     def groupsof(cls, num=1, sort_by=None, sort_ascending=True, select=None):
-        """Aggregates jobs of a set group size.
+        """Aggregate jobs into groupings of a given size.
 
-        By default aggregate of a single job is created.
+        By default, aggregates of a single job are created.
 
-        If the number of jobs present in the project is not divisible by the number
-        provided by the user, the last aggregate will be smaller and contain all
-        remaining jobs.
-        For instance, if 10 jobs are present in a project and they are aggregated in
-        groups of 3, then the generated aggregates will have lengths 3, 3, 3, and 1.
+        If the number of jobs present in the project is not divisible by the
+        number provided by the user, the last aggregate will be smaller and
+        contain the remaining jobs. For instance, if 10 jobs are present in a
+        project and they are aggregated in groups of 3, then the generated
+        aggregates will have lengths 3, 3, 3, and 1.
 
-        The code block below provides an example on how jobs can be aggregated in
-        groups of 2.
+        The code block below provides an example on how jobs can be aggregated
+        in groups of 2.
 
         .. code-block:: python
 
@@ -135,7 +141,7 @@ class aggregator:
 
     @classmethod
     def groupby(cls, key, default=None, sort_by=None, sort_ascending=True, select=None):
-        """Aggregates jobs according to matching state point key values.
+        """Aggregate jobs according to matching state point values.
 
         The below code block provides an example of how to aggregate jobs having a
         common state point parameter 'sp' whose value, when not found, is replaced by a
@@ -248,13 +254,14 @@ class aggregator:
         )
 
     def _get_unique_function_id(self, func):
-        """Generate unique id for the function passed. The id returned is used to generate
-        hash and compare arbitrary types which are callable like ``self._aggregator_function``
-        and ``self._select`` attributes.
+        """Generate unique id for the provided function.
 
-        Since ``select`` and ``aggregator_function`` are internal hence hash for the similar
-        functions can also differ. Hence we need to generate byte code in order to be able to
-        equate the functions properly.
+        Hashing the bytecode allows for the comparison of internal functions
+        like ``self._aggregator_function`` or ``self._select`` that may have
+        the same definitions but different hashes.
+
+        It is possible for equivalent functions to have different ids if the
+        bytecode is not identical.
         """
         try:
             return hash(func.__code__.co_code)

--- a/flow/directives.py
+++ b/flow/directives.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2020 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Directives define how workflows are executed.
+
+Directives affect both execution and submission, such as specifying the number
+of processors required for an operation.
+"""
 import functools
 import operator
 import sys
@@ -47,6 +55,7 @@ class _Directive:
         multiple ways to be set or are dependent in some way on other
         directives. If ``None`` or not provided, the set value is returned.
         Defaults to ``None``.
+
     """
 
     def __init__(
@@ -91,6 +100,7 @@ class _Directive:
             Returns a immediately validated value for the given directive, or if
             a callable was passed, a new callable is returned that wraps the
             given callable with a validator.
+
         """
         if callable(value):
 
@@ -115,6 +125,7 @@ class _Directives(MutableMapping):
         The sequence of all environment-specified directives. All other
         directives are user-specified and not validated. All environment
         directives must be specified at initialization.
+
     """
 
     def __init__(self, environment_directives):
@@ -189,6 +200,7 @@ class _Directives(MutableMapping):
             The jobs used to evaluate directives.
         parallel : bool
             Whether to aggregate according to parallel rules.
+
         """
         if aggregate:
             self._aggregate(other, jobs=jobs, parallel=parallel)
@@ -205,6 +217,7 @@ class _Directives(MutableMapping):
         ----------
         jobs :
             The jobs used to evaluate directives.
+
         """
         for key, value in self.items():
             self[key] = _evaluate(value, jobs)
@@ -293,7 +306,7 @@ def _finalize_np(np, directives):
 
 # Helper validators for defining _Directive
 def _no_aggregation(value, other):
-    """Returns its first argument.
+    """Return the first argument.
 
     This is used for directives that ignore aggregation rules.
     """

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -294,6 +294,10 @@ class StandardEnvironment(ComputeEnvironment):
 
     @classmethod
     def is_present(cls):
+        """Determine whether this specific compute environment is present.
+
+        The standard environment is always present, so this returns True.
+        """
         return True
 
 
@@ -349,6 +353,7 @@ class DefaultTorqueEnvironment(NodesEnvironment, TorqueEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to the parser."""
         super().add_args(parser)
         parser.add_argument(
             "-w", "--walltime", type=float, help="The wallclock time in hours."
@@ -374,6 +379,7 @@ class DefaultSlurmEnvironment(NodesEnvironment, SlurmEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to the parser."""
         super().add_args(parser)
         parser.add_argument(
             "--memory",
@@ -405,6 +411,7 @@ class DefaultLSFEnvironment(NodesEnvironment, LSFEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to the parser."""
         super().add_args(parser)
         parser.add_argument(
             "-w",

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 def setup(py_modules, **attrs):
-    """Setup function for environment modules.
+    """Set up user-defined environment modules.
 
     Use this function in place of setuptools.setup to not only install
     an environment's module, but also register it with the global signac
@@ -290,7 +290,7 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
 
 
 class StandardEnvironment(ComputeEnvironment):
-    """This is a default environment which is always present."""
+    """Default environment which is always present."""
 
     @classmethod
     def is_present(cls):
@@ -298,7 +298,7 @@ class StandardEnvironment(ComputeEnvironment):
 
 
 class TestEnvironment(ComputeEnvironment):
-    """This is a test environment.
+    """Test environment.
 
     The test environment will print a mocked submission script
     and submission commands to screen. This enables testing of
@@ -451,7 +451,7 @@ def _import_configured_environments():
 
 
 def registered_environments(import_configured=True):
-    """Returns a list of registered environments."""
+    """Return a list of registered environments."""
     if import_configured:
         _import_configured_environments()
     return list(ComputeEnvironment.registry.values())

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -296,13 +296,13 @@ class StandardEnvironment(ComputeEnvironment):
     def is_present(cls):
         """Determine whether this specific compute environment is present.
 
-        The standard environment is always present, so this returns True.
+        The StandardEnvironment is always present, so this returns True.
         """
         return True
 
 
 class TestEnvironment(ComputeEnvironment):
-    """Test environment.
+    """Environment used for testing.
 
     The test environment will print a mocked submission script
     and submission commands to screen. This enables testing of

--- a/flow/environments/incite.py
+++ b/flow/environments/incite.py
@@ -35,6 +35,18 @@ class SummitEnvironment(DefaultLSFEnvironment):
 
     @template_filter
     def calc_num_nodes(cls, resource_sets, parallel=False):
+        """Compute the number of nodes needed.
+
+        :param resource_sets:
+            Resource sets for each operation, as a sequence of tuples of
+            (number of sets, number of tasks, CPUs per task, GPUs).
+        :type resource_sets:
+            iterable
+        :param parallel:
+            Whether operations should run in parallel or serial.
+        :type parallel:
+            bool
+        """
         nodes_used_final = 0
         cores_used = gpus_used = nodes_used = 0
         for nsets, tasks, cpus_per_task, gpus in resource_sets:
@@ -62,6 +74,14 @@ class SummitEnvironment(DefaultLSFEnvironment):
 
     @template_filter
     def guess_resource_sets(cls, operation):
+        """Determine the resources sets needed for an operation.
+
+        :param operation:
+            The operation whose directives will be used to compute the resource
+            set.
+        :type operation:
+            :class:`flow.BaseFlowOperation`
+        """
         ntasks = max(operation.directives.get("nranks", 1), 1)
         np = operation.directives.get("np", ntasks)
 
@@ -87,6 +107,7 @@ class SummitEnvironment(DefaultLSFEnvironment):
 
     @classmethod
     def jsrun_options(cls, resource_set):
+        """Return jsrun options for the provided resource set."""
         nsets, tasks, cpus, gpus = resource_set
         cuda_aware_mpi = (
             "--smpiargs='-gpu'" if (nsets > 0 or tasks > 0) and gpus > 0 else ""

--- a/flow/environments/umich.py
+++ b/flow/environments/umich.py
@@ -17,6 +17,7 @@ class GreatLakesEnvironment(DefaultSlurmEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to parser."""
         super().add_args(parser)
         parser.add_argument(
             "--partition",

--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -23,6 +23,7 @@ class CometEnvironment(DefaultSlurmEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to parser."""
         super().add_args(parser)
 
         parser.add_argument(
@@ -83,6 +84,7 @@ class Stampede2Environment(DefaultSlurmEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to parser."""
         super().add_args(parser)
         parser.add_argument(
             "--partition",
@@ -149,6 +151,7 @@ class BridgesEnvironment(DefaultSlurmEnvironment):
 
     @classmethod
     def add_args(cls, parser):
+        """Add arguments to parser."""
         super().add_args(parser)
         parser.add_argument(
             "--partition",
@@ -167,4 +170,8 @@ class BridgesEnvironment(DefaultSlurmEnvironment):
         )
 
 
-__all__ = ["CometEnvironment", "BridgesEnvironment", "Stampede2Environment"]
+__all__ = [
+    "CometEnvironment",
+    "Stampede2Environment",
+    "BridgesEnvironment",
+]

--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -60,11 +60,13 @@ class Stampede2Environment(DefaultSlurmEnvironment):
 
     @template_filter
     def return_and_increment(cls, increment):
-        """Increment the base offset, then return the value prior to incrementing.
+        """Increment the base offset, then return the prior value.
 
         Note that this filter is designed for use at submission time, and the
-        environment variable will be used upon script generation. At run time, the
-        base offset will be set only once (when run initializes the environment)."""
+        environment variable will be used upon script generation. At run time,
+        the base offset will be set only once (when run initializes the
+        environment).
+        """
         cls.base_offset += increment
         return cls.base_offset - increment
 
@@ -74,7 +76,8 @@ class Stampede2Environment(DefaultSlurmEnvironment):
 
         This function is a hackish solution to get around the fact that Jinja has
         very limited support for direct modification of Python objects, and we need
-        to be able to reset the offset between bundles."""
+        to be able to reset the offset between bundles.
+        """
         cls.base_offset -= int(value)
         return ""
 

--- a/flow/errors.py
+++ b/flow/errors.py
@@ -46,10 +46,12 @@ class UserOperationError(RuntimeError):
 class TemplateError(Jinja2Extension):
     """Indicates an error in a jinja2 template."""
 
-    # ref:http://jinja.pocoo.org/docs/2.10/extensions/#jinja-extensions
+    # Reference: https://jinja.palletsprojects.com/en/2.11.x/extensions/
+    # The tags are a set of strings that trigger the parse method.
     tags = {"raise"}
 
     def parse(self, parser):
+        """Call err method when raise occurs in a template."""
         lineno = next(parser.stream).lineno
         args = [parser.parse_expression()]
         return jinja2.nodes.CallBlock(
@@ -57,4 +59,5 @@ class TemplateError(Jinja2Extension):
         ).set_lineno(lineno)
 
     def err(self, msg, caller):
+        """Raise a template error."""
         raise jinja2.TemplateError(msg)

--- a/flow/errors.py
+++ b/flow/errors.py
@@ -51,7 +51,7 @@ class TemplateError(Jinja2Extension):
     tags = {"raise"}
 
     def parse(self, parser):
-        """Call err method when raise occurs in a template."""
+        """Call :meth:`TemplateError.err` when a template raises an Exception."""
         lineno = next(parser.stream).lineno
         args = [parser.parse_expression()]
         return jinja2.nodes.CallBlock(

--- a/flow/labels.py
+++ b/flow/labels.py
@@ -27,6 +27,15 @@ class label:
         self.name = name
 
     def __call__(self, func):
+        """Add the function as a label.
+
+        This call operator allows the class to be used as a decorator.
+
+        :param func:
+            The function to decorate.
+        :type func:
+            callable
+        """
         func._label = True
         if self.name is not None:
             func._label_name = self.name
@@ -40,6 +49,15 @@ class staticlabel(label):
     """
 
     def __call__(self, func):
+        """Add the function as a label.
+
+        This call operator allows the class to be used as a decorator.
+
+        :param func:
+            The function to decorate.
+        :type func:
+            callable
+        """
         return staticmethod(super().__call__(func))
 
 
@@ -50,6 +68,15 @@ class classlabel(label):
     """
 
     def __call__(self, func):
+        """Add the function as a label.
+
+        This call operator allows the class to be used as a decorator.
+
+        :param func:
+            The function to decorate.
+        :type func:
+            callable
+        """
         return classmethod(super().__call__(func))
 
 

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -130,9 +130,19 @@ class directives:
 
     @classmethod
     def copy_from(cls, func):
+        """Copy directives from another operation."""
         return cls(**getattr(func, "_flow_directives", {}))
 
     def __call__(self, func):
+        """Add directives to the function.
+
+        This call operator allows the class to be used as a decorator.
+
+        :param func:
+            The function to decorate.
+        :type func:
+            callable
+        """
         directives = getattr(func, "_flow_directives", {})
         directives.update(self.kwargs)
         setattr(func, "_flow_directives", directives)

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""This module implements the run() function, which when called equips
-a regular Python module with a command line interface, which can be used
-to execute functions defined within the same module, that operate on a
-signac data space.
+"""Defines operation decorators and a simple command line interface ``run``.
+
+This module implements the run() function, which when called equips a regular
+Python module with a command line interface. This interface can be used to
+execute functions defined within the same module that operate on a signac data
+space.
+
+See also: :class:`~.FlowProject`.
 """
 import argparse
 import inspect
@@ -21,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def cmd(func):
-    """Specifies that ``func`` returns a shell command.
+    """Indicate that ``func`` returns a shell command with this decorator.
 
     If this function is an operation function defined by :class:`~.FlowProject`, it will
     be interpreted to return a shell command, instead of executing the function itself.
@@ -49,7 +53,7 @@ def cmd(func):
 
 
 def with_job(func):
-    """Specifies that ``func(arg)`` will use ``arg`` as a context manager.
+    """Use ``arg`` as a context manager for ``func(arg)`` with this decorator.
 
     If this function is an operation function defined by :class:`~.FlowProject`, it will
     be the same as using ``with job:``.
@@ -136,7 +140,7 @@ class directives:
 
 
 def _get_operations(include_private=False):
-    """Yields the name of all functions that qualify as an operation function.
+    """Yield the name of all functions that qualify as an operation function.
 
     The module is inspected and all functions that have only one argument
     is yielded. Unless the 'include_private' argument is True, all private

--- a/flow/project.py
+++ b/flow/project.py
@@ -173,7 +173,7 @@ class _condition:
 
     @classmethod
     def true(cls, key):
-        """Evaluate job document key for True value.
+        """Evaluate if a document key is True for the job(s).
 
         Returns True if the specified key is present in the job document(s) and
         evaluates to True.

--- a/flow/project.py
+++ b/flow/project.py
@@ -749,12 +749,14 @@ class FlowOperation(BaseFlowOperation):
 class FlowGroupEntry:
     """A FlowGroupEntry registers operations for inclusion into a :py:class:`FlowGroup`.
 
-    Has two methods for adding operations: the call operator ``self()`` and
-    :meth:`~.with_directives`.  Using :meth:`~.with_directives` takes one
-    argument, ``directives``, which are applied to the operation when running
-    through the group. This overrides the default directives specified by
-    :meth:`flow.directives`. Calling the object directly will then use the
-    default directives.
+    Operation functions can be marked for inclusion into a :class:`FlowGroup`
+    by decorating the functions with a corresponding :class:`FlowGroupEntry`.
+    If the operation requires specific directives, :meth:`~.with_directives`
+    accepts keyword arguments that are mapped to directives and returns a
+    decorator that can be applied to the operation to mark it for inclusion in
+    the group and indicate that it should be executed using the specified
+    directives. This overrides the default directives specified by
+    :meth:`flow.directives`.
 
     :param name:
         The name of the :py:class:`FlowGroup` to be created.

--- a/flow/project.py
+++ b/flow/project.py
@@ -736,6 +736,13 @@ class FlowOperation(BaseFlowOperation):
         return f"{type(self).__name__}(op_func='{self._op_func}')"
 
     def __call__(self, *jobs):
+        r"""Call the operation on the provided jobs.
+
+        :param \*jobs:
+            The jobs passed to the operation.
+        :type \*jobs:
+            One or more instances of :class:`.Job`.
+        """
         return self._op_func(*jobs)
 
 
@@ -773,7 +780,7 @@ class FlowGroupEntry:
     def __call__(self, func):
         """Add the function into the group's operations.
 
-        This call operator allows the group to be used as a decorator.
+        This call operator allows the class to be used as a decorator.
 
         :param func:
             The function to decorate.

--- a/flow/project.py
+++ b/flow/project.py
@@ -186,7 +186,7 @@ class _condition:
 
     @classmethod
     def false(cls, key):
-        """Evaluate job document key for False value.
+        """Evaluate if a document key is False for the job(s).
 
         Returns True if the specified key is present in the job document(s) and
         evaluates to False.

--- a/flow/project.py
+++ b/flow/project.py
@@ -154,7 +154,6 @@ class _condition:
 
     def __init__(self, condition, tag=None):
         """Add tag to differentiate built-in conditions during graph detection."""
-
         if tag is None:
             try:
                 tag = condition.__code__.co_code
@@ -165,7 +164,7 @@ class _condition:
 
     @classmethod
     def isfile(cls, filename):
-        """True if the specified file exists for the job(s)."""
+        """Determine if the specified file exists for the job(s)."""
 
         def _isfile(*jobs):
             return all(job.isfile(filename) for job in jobs)
@@ -174,8 +173,11 @@ class _condition:
 
     @classmethod
     def true(cls, key):
-        """True if the specified key is present in the job document(s) and
-        evaluates to True."""
+        """Evaluate job document key for True value.
+
+        Returns True if the specified key is present in the job document(s) and
+        evaluates to True.
+        """
 
         def _document(*jobs):
             return all(job.document.get(key, False) for job in jobs)
@@ -184,8 +186,11 @@ class _condition:
 
     @classmethod
     def false(cls, key):
-        """True if the specified key is present in the job document(s) and
-        evaluates to False."""
+        """Evaluate job document key for False value.
+
+        Returns True if the specified key is present in the job document(s) and
+        evaluates to False.
+        """
 
         def _no_document(*jobs):
             return all(not job.document.get(key, False) for job in jobs)
@@ -194,13 +199,13 @@ class _condition:
 
     @classmethod
     def never(cls, func):
-        """Returns False."""
+        """Return False."""
         cls.current_arbitrary_tag += 1
         return cls(lambda _: False, str(cls.current_arbitrary_tag))(func)
 
     @classmethod
     def not_(cls, condition):
-        """Returns ``not condition(*jobs)`` for the provided condition function."""
+        """Return ``not condition(*jobs)`` for the provided condition function."""
 
         def _not(*jobs):
             return not condition(*jobs)
@@ -209,9 +214,12 @@ class _condition:
 
 
 def _create_all_metacondition(condition_dict, *other_funcs):
-    """Standard function for generating aggregate metaconditions that require
-    *all* provided conditions to be met. The resulting metacondition is
-    constructed with appropriate information for graph detection."""
+    """Generate metacondition requiring all provided conditions to be true.
+
+    This function generates an aggregate metaconditions that requires *all*
+    provided conditions to be met. The resulting metacondition is constructed
+    with appropriate information for graph detection.
+    """
     condition_list = [c for f in other_funcs for c in condition_dict[f]]
 
     def _flow_metacondition(*jobs):
@@ -222,10 +230,10 @@ def _create_all_metacondition(condition_dict, *other_funcs):
 
 
 def _make_bundles(operations, size=None):
-    """Utility function for the generation of bundles.
+    """Slice an iterable of operations into equally sized bundles.
 
-    This function splits an iterable of operations into equally
-    sized bundles and a possibly smaller final bundle.
+    This utility function splits an iterable of operations into equally sized
+    bundles. The final bundle may be smaller than the specified size.
     """
     if size == 0:
         size = None
@@ -239,11 +247,11 @@ def _make_bundles(operations, size=None):
 
 
 class _JobOperation:
-    """This class represents the information needed to execute one group for one job.
+    """Class containing execution information for one group and one job.
 
     The execution or submission of a :py:class:`FlowGroup` uses a passed-in command
     which can either be a string or function with no arguments that returns a shell
-    executable command.  The shell executable command won't be used if it is
+    executable command. The shell executable command won't be used if it is
     determined that the group can be executed without forking.
 
     .. note::
@@ -361,7 +369,7 @@ class _JobOperation:
 
 @deprecated(deprecated_in="0.11", removed_in="0.13", current_version=__version__)
 class JobOperation(_JobOperation):
-    """This class represents the information needed to execute one group for one job.
+    """Class containing execution information for one group and one job.
 
     The execution or submission of a :py:class:`FlowGroup` uses a passed-in command
     which can either be a string or function with no arguments that returns a shell
@@ -442,7 +450,7 @@ class JobOperation(_JobOperation):
 
 
 class _SubmissionJobOperation(_JobOperation):
-    R"""This class represents the information needed to submit one group for one job.
+    r"""Class containing submission information for one group and one job.
 
     This class extends :py:class:`_JobOperation` to include a set of groups
     that will be executed via the "run" command. These groups are known at
@@ -619,22 +627,23 @@ class BaseFlowOperation:
         :type job:
             :class:`~signac.contrib.job.Job`
         :param ignore_conditions:
-            Specify if pre and/or post conditions check is to be ignored for eligibility check.
-            The default is :py:class:`IgnoreConditions.NONE`.
+            Specify if pre and/or post conditions check is to be ignored for
+            eligibility check.  The default is
+            :py:class:`IgnoreConditions.NONE`.
         :type ignore_conditions:
             :py:class:`~.IgnoreConditions`
         """
         return self._eligible((job,), ignore_conditions)
 
     def _complete(self, jobs):
-        """True when all post-conditions are met."""
+        """Check if all post-conditions are met."""
         if len(self._postconditions) > 0:
             return all(cond(jobs) for cond in self._postconditions)
         return False
 
     @deprecated(deprecated_in="0.11", removed_in="0.13", current_version=__version__)
     def complete(self, job):
-        """True when all post-conditions are met."""
+        """Check if all post-conditions are met."""
         return self._complete((job,))
 
 
@@ -733,11 +742,12 @@ class FlowOperation(BaseFlowOperation):
 class FlowGroupEntry:
     """A FlowGroupEntry registers operations for inclusion into a :py:class:`FlowGroup`.
 
-    Has two methods for adding operations: ``self()`` and ``with_directives``.
-    Using ``with_directives`` takes one argument, ``directives``, which are
-    applied to the operation when running through the group. This overrides
-    the default directives specified by ``@flow.directives``. Calling the object
-    directly will then use the default directives.
+    Has two methods for adding operations: the call operator ``self()`` and
+    :meth:`~.with_directives`.  Using :meth:`~.with_directives` takes one
+    argument, ``directives``, which are applied to the operation when running
+    through the group. This overrides the default directives specified by
+    :meth:`flow.directives`. Calling the object directly will then use the
+    default directives.
 
     :param name:
         The name of the :py:class:`FlowGroup` to be created.
@@ -761,7 +771,9 @@ class FlowGroupEntry:
         self.aggregator = aggregator
 
     def __call__(self, func):
-        """Decorator that adds the function into the group's operations.
+        """Add the function into the group's operations.
+
+        This call operator allows the group to be used as a decorator.
 
         :param func:
             The function to decorate.
@@ -790,7 +802,7 @@ class FlowGroupEntry:
             func._flow_group_operation_directives = {self.name: directives}
 
     def with_directives(self, directives):
-        """Returns a decorator that sets group specific directives to the operation.
+        """Return a decorator that sets group specific directives to the operation.
 
         :param directives:
             Directives to use for resource requests and running the operation
@@ -965,7 +977,7 @@ class FlowGroup:
         return any(op._eligible(jobs, ignore_conditions) for op in self)
 
     def _complete(self, jobs):
-        """True when post-conditions are met for all operations in the group.
+        """Check if post-conditions are met for all operations in the group.
 
         :param jobs:
             The signac job handles.
@@ -1004,7 +1016,7 @@ class FlowGroup:
 
     @deprecated(deprecated_in="0.11", removed_in="0.13", current_version=__version__)
     def complete(self, job):
-        """True when all BaseFlowOperation post-conditions are met.
+        """Check if all BaseFlowOperation post-conditions are met.
 
         :param job:
             A :class:`signac.contrib.job.Job` from the signac workspace.
@@ -1039,7 +1051,7 @@ class FlowGroup:
             self.operation_directives[name] = directives
 
     def isdisjoint(self, group):
-        """Returns whether two groups are disjoint (do not share any common operations).
+        """Return whether two groups are disjoint (do not share any common operations).
 
         :param group:
             The other FlowGroup to compare to.
@@ -1163,9 +1175,12 @@ class FlowGroup:
         )
 
         def _get_run_ops(ignore_ops, additional_ignores_flag):
-            """Get operations that match the combination of the conditions required by
-            _create_submission_job_operation and the ignored flags, and remove operations
-            in the ignore_ops list."""
+            """Get all runnable operations.
+
+            Returns operations that match the combination of the conditions
+            required by ``_create_submission_job_operation`` and the ignored
+            flags, and remove operations in the ``ignore_ops`` list.
+            """
             return list(
                 set(
                     self._create_run_job_operations(
@@ -1371,7 +1386,7 @@ class _FlowProjectClass(type):
 
             @classmethod
             def copy_from(cls, *other_funcs):
-                """Copies pre-conditions from another operation.
+                """Copy pre-conditions from another operation.
 
                 True if and only if all pre conditions of other operation
                 function(s) are met.
@@ -1449,7 +1464,7 @@ class _FlowProjectClass(type):
 
             @classmethod
             def copy_from(cls, *other_funcs):
-                """Copies post-conditions from another operation.
+                """Copy post-conditions from another operation.
 
                 True if and only if all post conditions of other operation
                 function(s) are met.
@@ -1536,7 +1551,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         self._register_aggregates()
 
     def _setup_template_environment(self):
-        """Setup the jinja2 template environment.
+        """Set up the jinja2 template environment.
 
         The templating system is used to generate templated scripts for the script()
         and _submit_operations() / submit() function and the corresponding command line
@@ -1678,8 +1693,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         return label_func
 
     def detect_operation_graph(self):
-        """Determine the directed acyclic graph defined by operation pre- and
-        post-conditions.
+        """Determine the directed acyclic graph given by operation conditions.
 
         In general, executing a given operation registered with a FlowProject
         just involves checking the operation's pre- and post-conditions to
@@ -1742,10 +1756,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             return [condition._callback for condition in conditions]
 
         def unpack_conditions(condition_functions):
-            """Identify any metaconditions in the list and reduce them to the
-            functions that they are composed of. The callbacks argument is used
-            in recursive calls to the function and appended to directly, but
-            only returned at the end."""
+            """Create a set of callbacks from condition functions.
+
+            Metaconditions in the list of condition functions are reduced into
+            the functions that they are composed of. All condition functions
+            must have a `_flow_tag` attribute defined.
+            """
             callbacks = set()
             for condition_function in condition_functions:
                 # The condition function may not have a __name__ attribute in
@@ -1793,10 +1809,10 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         return mat
 
     def _register_class_labels(self):
-        """This function registers all label functions, which are part of the class definition.
+        """Register all label functions which are part of the class definition.
 
-        To register a class method or function as label function, use the generalized label()
-        function.
+        To register a class method or function as a label function, use the
+        :meth:`~.FlowProject.label()` class method as a decorator.
         """
 
         def predicate(member):
@@ -2117,17 +2133,16 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         ignore_errors,
         status_parallelization="thread",
     ):
-        """Fetch status associated for either all the jobs associated in a project
-        or jobs specified by a user
+        """Fetch status for the provided aggregates / jobs.
 
         :param aggregates:
             The aggregates for which a user requested to fetch status.
         :type aggregates:
             list
         :param distinct_jobs:
-            Distinct jobs fetched from the ids provided in the ``jobs`` argument.
-            This is used for fetching labels for a job because a label is not associated
-            with an aggregate.
+            Distinct jobs fetched from the ids provided in the ``jobs``
+            argument.  This is used for fetching labels for a job because a
+            label is not associated with an aggregate.
         :type distinct_jobs:
             list of :py:class:`signac.contrib.job.Job`
         :param ignore_errors:
@@ -2135,8 +2150,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         :type ignore_errors:
             bool
         :param status_parallelization:
-            Nature of parallelization for fetching the status.
-            Default value parallelizes using ``multiprocessing.ThreadPool()``
+            Parallelization mode for fetching the status. By default, thread
+            parallelism is used.
         :type status_parallelization:
             str
         :returns:
@@ -2990,7 +3005,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         project instance and the operations before submitting them to the process pool to
         enable us to try different pool and pickle module combinations.
         """
-
         try:
             serialized_root = pickle.dumps(self.root_directory())
             serialized_operations = pickle.dumps(self._operations)
@@ -3362,11 +3376,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     @classmethod
     def _verify_group_compatibility(cls, groups):
-        """Verifies that all selected groups can be submitted together."""
+        """Verify that all selected groups can be submitted together."""
         return all(a.isdisjoint(b) for a in groups for b in groups if a != b)
 
     def _aggregate_is_in_project(self, aggregate):
-        """Verifies that the aggregate belongs to this project."""
+        """Verify that the aggregate belongs to this project."""
         return any(
             get_aggregate_id(aggregate) in aggregates
             for aggregates in self._stored_aggregates
@@ -3374,7 +3388,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     @staticmethod
     def _is_selected_aggregate(aggregate, jobs):
-        """Verifies whether the aggregate is present in the provided jobs.
+        """Verify whether the aggregate is present in the provided jobs.
 
         Providing ``jobs=None`` indicates that no specific job is provided by
         the user and hence ``aggregate`` is eligible for further evaluation.
@@ -3957,7 +3971,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
     @classmethod
     def _add_operation_bundling_arg_group(cls, parser):
         """Add argument group to parser for operation bundling."""
-
         bundling_group = parser.add_argument_group(
             "bundling",
             "Bundle multiple operations for execution, e.g., to submit them "
@@ -4099,7 +4112,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         )
 
     def labels(self, job):
-        """Yields all labels for the given ``job``.
+        """Yield all labels for the given ``job``.
 
         See also: :meth:`~.label`
         """
@@ -4246,9 +4259,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
     def next_operations(self, *jobs, ignore_conditions=IgnoreConditions.NONE):
         r"""Determine the next eligible operations for provided job(s).
 
-        :param *jobs:
+        :param \*jobs:
             The signac job handles.
-        :type *jobs:
+        :type \*jobs:
             One or more instances of :class:`.Job`.
         :param ignore_conditions:
             Specify if pre and/or post conditions check is to be ignored for eligibility check.
@@ -4384,7 +4397,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 self._operations[name] = FlowOperation(op_func=func, **params)
 
     def _register_aggregates(self):
-        """Generate aggregates for every operation or group in a FlowProject"""
+        """Generate aggregates for every operation or group in a FlowProject."""
         stored_aggregates = {}
         for _aggregator, groups in self._aggregator_per_group.items():
             stored_aggregates[_aggregator._create_AggregatesStore(self)] = groups
@@ -4465,12 +4478,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     @property
     def operations(self):
-        """The dictionary of operations that have been added to the workflow."""
+        """Get the dictionary of operations that have been added to the workflow."""
         return self._operations
 
     @property
     def groups(self):
-        """The dictionary of groups that have been added to the workflow."""
+        """Get the dictionary of groups that have been added to the workflow."""
         return self._groups
 
     def _get_aggregate_store(self, group):
@@ -4491,8 +4504,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         return {}
 
     def _eligible_for_submission(self, flow_group, jobs):
-        """Determine if a flow_group is eligible for submission with a given
-        job-aggregate.
+        """Check flow_group eligibility for submission with a job-aggregate.
 
         By default, an operation is eligible for submission when it
         is not considered active, that means already queued or running.

--- a/flow/render_status.py
+++ b/flow/render_status.py
@@ -1,4 +1,7 @@
-# make separate python class for render_status
+# Copyright (c) 2020 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Status rendering logic."""
 from tqdm.auto import tqdm
 
 from .scheduling.base import JobStatus
@@ -25,7 +28,6 @@ class Renderer:
         :rtype:
             str
         """
-
         self.terminal_output = mistune.terminal(self.markdown_output)
         return self.terminal_output
 
@@ -37,7 +39,6 @@ class Renderer:
         :rtype:
             str
         """
-
         self.html_output = mistune.html(self.markdown_output)
         return self.html_output
 
@@ -88,8 +89,7 @@ class Renderer:
         :type output_format:
             str
         """
-
-        # use Jinja2 template for status output
+        # Use Jinja2 template for status output
         if template is None:
             if detailed and expand:
                 template = "status_expand.jinja"
@@ -116,7 +116,6 @@ class Renderer:
             :type width:
                 int
             """
-
             assert value >= 0 and total > 0
             bar_format = escape + f"|{{bar:{width}}}" + escape + "| {percentage:<0.2f}%"
             return tqdm.format_meter(
@@ -139,7 +138,6 @@ class Renderer:
             :type all_ops:
                 bool
             """
-
             return (
                 scheduler_status_code[job_op["scheduler_status"]] != "U"
                 or job_op["eligible"]
@@ -158,7 +156,6 @@ class Renderer:
             :type symbols:
                 dict
             """
-
             if operation_info["scheduler_status"] >= JobStatus.active:
                 op_status = "running"
             elif operation_info["scheduler_status"] > JobStatus.inactive:
@@ -172,12 +169,12 @@ class Renderer:
 
             return symbols[op_status]
 
-        def highlight(s, eligible, pretty):
-            """Change font to bold within jinja2 template
+        def highlight(string, eligible, pretty):
+            """Change font to bold within jinja2 template.
 
-            :param s:
+            :param string:
                 The string to be printed.
-            :type s:
+            :type string:
                 str
             :param eligible:
                 Boolean value for job eligibility.
@@ -189,9 +186,9 @@ class Renderer:
                 bool
             """
             if eligible and pretty:
-                return "**" + s + "**"
+                return "**" + string + "**"
             else:
-                return s
+                return string
 
         template_environment.filters["highlight"] = highlight
         template_environment.filters["draw_progressbar"] = draw_progressbar

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -36,9 +36,11 @@ class ClusterJob:
         return str(self._id())
 
     def name(self):
+        """Return the name of the cluster job."""
         return self._id()
 
     def status(self):
+        """Return the status of the cluster job."""
         return self._status
 
 

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -23,7 +23,7 @@ class JobStatus(enum.IntEnum):
 
 
 class ClusterJob:
-    """This class represents a cluster job."""
+    """Class representing a cluster job."""
 
     def __init__(self, jobid, status=None):
         self._job_id = jobid
@@ -48,18 +48,20 @@ class Scheduler:
     # The UNIX time stamp of the last scheduler query.
     _last_query = None
 
-    # The amount of time in seconds a user needs to wait, before we
-    # assume that repeated scheduler queries might risk a denial-of-service attack.
+    # The amount of time in seconds to wait between scheduler queries.
+    # Repeated scheduler queries might risk a denial-of-service attack.
     _dos_timeout = 10
 
     @classmethod
     def _prevent_dos(cls):
-        """This method should be called before querying the scheduler.
+        """Prevent denial of service by enforcing a back-off period.
 
-        If this method will raise an exception if it is called more than
-        once within a time window defined by the '_dos_timeout' class.
-        This is to prevent an (accidental) denial-of-service attack on
-        the scheduling system.
+        This method should *always* be called before querying the scheduler.
+
+        This method will raise an exception if it is called more than
+        once within a time window defined by the value of ``_dos_timeout``.
+        This is to prevent an (accidental) denial-of-service attack on the
+        scheduling system.
         """
         if cls._last_query is not None:
             if time.time() - cls._last_query < cls._dos_timeout:

--- a/flow/scheduling/fakescheduler.py
+++ b/flow/scheduling/fakescheduler.py
@@ -25,9 +25,13 @@ class FakeScheduler(Scheduler):
         return None
 
     def submit(self, script, **kwargs):
-        """Just print the script to screen."""
+        """Print the script to screen."""
         print(script)
 
     @classmethod
     def is_present(cls):
+        """Return False.
+
+        The fake scheduler is never present unless manually specified.
+        """
         return False

--- a/flow/scheduling/fakescheduler.py
+++ b/flow/scheduling/fakescheduler.py
@@ -21,9 +21,8 @@ class FakeScheduler(Scheduler):
     """
 
     def jobs(self):
-        """Yields nothing, since the FakeScheduler does not actually schedule any jobs."""
-        return
-        yield
+        """Return None, since the FakeScheduler does not schedule any jobs."""
+        return None
 
     def submit(self, script, **kwargs):
         """Just print the script to screen."""

--- a/flow/scheduling/lsf.py
+++ b/flow/scheduling/lsf.py
@@ -62,6 +62,7 @@ class LSFJob(ClusterJob):
         self._status = _parse_status(record["STAT"])
 
     def name(self):
+        """Return the name of the cluster job."""
         return self.record["JOB_NAME"]
 
 

--- a/flow/scheduling/lsf.py
+++ b/flow/scheduling/lsf.py
@@ -33,7 +33,6 @@ def _parse_status(s):
 
 def _fetch(user=None):
     """Fetch the cluster job status information from the LSF scheduler."""
-
     if user is None:
         user = getpass.getuser()
 

--- a/flow/scheduling/simple_scheduler.py
+++ b/flow/scheduling/simple_scheduler.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+"""Implementation of the scheduling system for the built-in simple scheduler."""
 import json
 import os
 import subprocess
@@ -10,6 +11,12 @@ from .base import ClusterJob, JobStatus, Scheduler
 
 
 class SimpleScheduler(Scheduler):
+    """Implementation of the abstract Scheduler class for SimpleScheduler.
+
+    This class allows us to submit cluster jobs to the built-in simple
+    scheduler and query their current status.
+    """
+
     @classmethod
     def is_present(cls):
         return bool(os.environ.get("SIMPLE_SCHEDULER"))

--- a/flow/scheduling/simple_scheduler.py
+++ b/flow/scheduling/simple_scheduler.py
@@ -19,18 +19,35 @@ class SimpleScheduler(Scheduler):
 
     @classmethod
     def is_present(cls):
+        """Return True if a SimpleScheduler is detected."""
         return bool(os.environ.get("SIMPLE_SCHEDULER"))
 
     def __init__(self):
         self.cmd = os.environ["SIMPLE_SCHEDULER"].split()
 
     def jobs(self):
+        """Yield cluster jobs by querying the scheduler."""
         cmd = self.cmd + ["status", "--json"]
         status = json.loads(subprocess.check_output(cmd).decode("utf-8"))
         for _id, doc in status.items():
             yield ClusterJob(doc["job_name"], JobStatus(doc["status"]))
 
     def submit(self, script, pretend=False, **kwargs):
+        """Submit a job script for execution to the scheduler.
+
+        :param script:
+            The job script submitted for execution.
+        :type script:
+            str
+        :param pretend:
+            If True, do not actually submit the script, but only simulate the submission.
+            Can be used to test whether the submission would be successful.
+            Please note: A successful "pretend" submission is not guaranteed to succeed.
+        :type pretend:
+            bool
+        :returns:
+            Returns True if the cluster job was successfully submitted, otherwise None.
+        """
         cmd = self.cmd + ["submit"]
         if pretend:
             print("# Submit command: {}".format(" ".join(cmd)))

--- a/flow/scheduling/simple_scheduler.py
+++ b/flow/scheduling/simple_scheduler.py
@@ -42,7 +42,7 @@ class SimpleScheduler(Scheduler):
         :param pretend:
             If True, do not actually submit the script, but only simulate the submission.
             Can be used to test whether the submission would be successful.
-            Please note: A successful "pretend" submission is not guaranteed to succeed.
+            A successful "pretend" submission is not guaranteed to succeed.
         :type pretend:
             bool
         :returns:

--- a/flow/scheduling/simple_scheduler.py
+++ b/flow/scheduling/simple_scheduler.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""Implementation of the scheduling system for the built-in simple scheduler."""
+"""Implementation of the scheduling system for the bundled ``simple-scheduler`` script."""
 import json
 import os
 import subprocess
@@ -11,7 +11,11 @@ from .base import ClusterJob, JobStatus, Scheduler
 
 
 class SimpleScheduler(Scheduler):
-    """Implementation of the abstract Scheduler class for SimpleScheduler.
+    """Implementation of the abstract Scheduler class for the bundled ``simple-scheduler``.
+
+    The package signac-flow includes a script in ``bin/simple-scheduler`` that
+    is a simple model of a cluster job scheduler. The ``simple-scheduler``
+    script is designed primarily for testing and demonstration.
 
     This class allows us to submit cluster jobs to the built-in simple
     scheduler and query their current status.

--- a/flow/scheduling/status.py
+++ b/flow/scheduling/status.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+"""Methods for determining and caching job status information."""
 import logging
 
 from .base import JobStatus
@@ -27,7 +28,6 @@ def _status_scheduler(scheduler_job_id, scheduler_jobs):
 
 def update_status(job, scheduler_jobs=None):
     """Update the job's status dictionary."""
-
     # The status docs maps the scheduler job id to a distinct JobStatus value.
     status_doc = job.document.setdefault("status", {})
 

--- a/flow/scheduling/torque.py
+++ b/flow/scheduling/torque.py
@@ -59,9 +59,11 @@ class TorqueJob(ClusterJob):
         return str(self._id())
 
     def name(self):
+        """Return the name of the cluster job."""
         return self.node.find("Job_Name").text
 
     def status(self):
+        """Return the status of the cluster job."""
         job_state = self.node.find("job_state").text
         if job_state == "R":
             return JobStatus.active

--- a/flow/template.py
+++ b/flow/template.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""This module contains the FlowProject module templates.
+"""FlowProject module templates.
 
 These templates can be initialized via the init() function defined
 in this module and the main 'flow' command line interface.

--- a/flow/util/__init__.py
+++ b/flow/util/__init__.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"Defines the API for the util sub package."
+"""Defines the API for the util subpackage."""
 from . import misc, mistune, template_filters, translate
 
-__all__ = ["misc", "translate", "template_filters", "mistune"]
+__all__ = [
+    "misc",
+    "mistune",
+    "template_filters",
+    "translate",
+]

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -1,8 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""Contains logic for working with flow related information
-stored in the signac config"""
+"""Contains logic for working with flow related information stored in the signac config."""
 from signac.common import config
 
 from ..errors import ConfigKeyError

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -140,6 +140,11 @@ class TrackGetItemDict(dict):
         return super().__getitem__(key)
 
     def get(self, key, default=None):
+        """Return the value for key if key is in the dictionary, else default.
+
+        If default is not given, it defaults to ``None``, so that this method
+        never raises a :class:`KeyError`.
+        """
         self._keys_used.add(key)
         return super().get(key, default)
 

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+"""Miscellaneous utility functions."""
 import argparse
 import json
 import logging
@@ -104,6 +105,7 @@ def add_path_to_environment_pythonpath(path):
 
 @contextmanager
 def add_cwd_to_environment_pythonpath():
+    """Add current working directory to PYTHONPATH."""
     with add_path_to_environment_pythonpath(os.getcwd()):
         yield
 
@@ -148,6 +150,11 @@ class TrackGetItemDict(dict):
 
 
 def roundrobin(*iterables):
+    """Round robin iterator.
+
+    Cycles through a sequence of iterables, taking one item from each iterable
+    until all iterables are exhausted.
+    """
     # From: https://docs.python.org/3/library/itertools.html#itertools-recipes
     # roundrobin('ABC', 'D', 'EF') --> A D E B F C
     # Recipe credited to George Sakkis

--- a/flow/util/translate.py
+++ b/flow/util/translate.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"Helper functions to keep track of abbreviations meant for output on screen."
+"""Helper functions to keep track of abbreviations meant for output on screen."""
 
 
 def abbreviate(x, a):

--- a/flow/version.py
+++ b/flow/version.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""Define signac-flow version."""
+"""Define the signac-flow version."""
 
 __version__ = "0.11.0"
 

--- a/flow/version.py
+++ b/flow/version.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+"""Define signac-flow version."""
 
 __version__ = "0.11.0"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,10 @@ description-file = README.md
 python-tag = py3
 
 [pydocstyle]
-match = template_filters.py
+match = ^((?!\.sync-zenodo-metadata|setup).)*\.py$
+match-dir = ^((?!tests|mistune).)*$
+ignore-decorators = "deprecated"
+ignore = D105, D107, D203, D204, D213
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,7 @@ python-tag = py3
 match = ^((?!\.sync-zenodo-metadata|setup).)*\.py$
 match-dir = ^((?!\.|tests|mistune).)*$
 ignore-decorators = "deprecated"
-# Remove D102 from this list! D102 indicates missing docstrings.
-ignore = D102,D105,D107,D203,D204,D213
+ignore = D105,D107,D203,D204,D213
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ python-tag = py3
 
 [pydocstyle]
 match = ^((?!\.sync-zenodo-metadata|setup).)*\.py$
-match-dir = ^((?!tests|mistune).)*$
+match-dir = ^((?!\.|tests|mistune).)*$
 ignore-decorators = "deprecated"
 ignore = D105, D107, D203, D204, D213
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ python-tag = py3
 match = ^((?!\.sync-zenodo-metadata|setup).)*\.py$
 match-dir = ^((?!\.|tests|mistune).)*$
 ignore-decorators = "deprecated"
-ignore = D105, D107, D203, D204, D213
+# Remove D102 from this list! D102 indicates missing docstrings.
+ignore = D102,D105,D107,D203,D204,D213
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Description
This PR adds docstrings to all classes and methods that were missing them.
It also enforces pydocstyle (with the same config as `signac`).

## Motivation and Context
Improves docs by ...a lot.

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
