### PR TITLE
Reduce calls to getfqdn

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ Changed
 Fixed
 +++++
 
-- Automatic environment detection no longer hangs as long if socket.fqdn times out (#339)
+- Cache the fully qualified domain name during environment detection to fix a performance issue on macOS (#339, #394)
 
 Version 0.11
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,10 @@ Changed
 +++++++
 - Command line interface for ``exec`` changed parameter name from ``jobid`` to ``job_id`` (#363).
 
+Fixed
++++++
+
+- Automatic environment detection no longer hangs as long if socket.fqdn times out (#339)
 
 Version 0.11
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ Changed
 Fixed
 +++++
 
-- Cache the fully qualified domain name during environment detection to fix a performance issue on macOS (#339, #394)
+- Cache the fully qualified domain name during environment detection to fix a performance issue on macOS (#339, #394).
 
 Version 0.11
 ============

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -44,8 +44,11 @@ logger = logging.getLogger(__name__)
 
 @lru_cache(maxsize=1)
 def _cached_fqdn():
-    """We cache this since fetching the fully qualified domain name can be
-    slow on macOS."""
+    """Return the fully qualified domain name.
+    
+    This value is cached because fetching the fully qualified domain name can
+    be slow on macOS.
+    """
     return socket.getfqdn()
 
 

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -15,8 +15,8 @@ import logging
 import os
 import re
 import socket
-from functools import lru_cache
 from collections import OrderedDict
+from functools import lru_cache
 
 from signac.common import config
 

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -40,6 +40,20 @@ from .util import config as flow_config
 
 logger = logging.getLogger(__name__)
 
+_fqdn = None
+def _cached_fqdn():
+    """Returns the fully qualified domain name.
+
+    If called for the first time in a session, call socket.getfqdn
+    and cache the value. If called again, return the cached value.
+    Solves #339
+    """
+    if _fqdn is None:
+        _fqdn = socket.getfqdn()
+        import pdb
+        pdb.set_trace()
+    return _fqdn
+
 
 def setup(py_modules, **attrs):
     """Setup function for environment modules.
@@ -115,20 +129,9 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
     submit_flags = None
     template = "base_script.sh"
     mpi_cmd = "mpiexec"
-    fqdn = None
 
 
-    @classmethod
-    def _cached_fqdn(cls):
-        """Returns the fully qualified domain name.
 
-        If called for the first time in a session, call socket.getfqdn
-        and cache the value. If called again, return the cached value.
-        Solves #339
-        """
-        if cls.fqdn is None:
-            cls.fqdn = socket.getfqdn()
-        return cls.fqdn
 
 
     @classmethod
@@ -145,7 +148,7 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
             else:
                 return cls.scheduler_type.is_present()
         else:
-            return re.match(cls.hostname_pattern, cls._cached_fqdn()) is not None
+            return re.match(cls.hostname_pattern, _cached_fqdn()) is not None
 
     @classmethod
     def get_scheduler(cls):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -45,7 +45,6 @@ logger = logging.getLogger(__name__)
 @lru_cache(maxsize=1)
 def _cached_fqdn():
     """Return the fully qualified domain name.
-    
     This value is cached because fetching the fully qualified domain name can
     be slow on macOS.
     """

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import socket
+from functools import lru_cache
 from collections import OrderedDict
 
 from signac.common import config
@@ -40,7 +41,7 @@ from .util import config as flow_config
 
 logger = logging.getLogger(__name__)
 
-_fqdn = None
+@lru_cache(maxsize=1)
 def _cached_fqdn():
     """Returns the fully qualified domain name.
 
@@ -48,11 +49,7 @@ def _cached_fqdn():
     and cache the value. If called again, return the cached value.
     Solves #339
     """
-    if _fqdn is None:
-        _fqdn = socket.getfqdn()
-        import pdb
-        pdb.set_trace()
-    return _fqdn
+    return socket.getfqdn()
 
 
 def setup(py_modules, **attrs):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -41,6 +41,7 @@ from .util import config as flow_config
 
 logger = logging.getLogger(__name__)
 
+
 @lru_cache(maxsize=1)
 def _cached_fqdn():
     """Returns the fully qualified domain name.
@@ -126,10 +127,6 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
     submit_flags = None
     template = "base_script.sh"
     mpi_cmd = "mpiexec"
-
-
-
-
 
     @classmethod
     def is_present(cls):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -115,6 +115,21 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
     submit_flags = None
     template = "base_script.sh"
     mpi_cmd = "mpiexec"
+    fqdn = None
+
+
+    @classmethod
+    def _cached_fqdn(cls):
+        """Returns the fully qualified domain name.
+
+        If called for the first time in a session, call socket.getfqdn
+        and cache the value. If called again, return the cached value.
+        Solves #339
+        """
+        if cls.fqdn is None:
+            cls.fqdn = socket.getfqdn()
+        return cls.fqdn
+
 
     @classmethod
     def is_present(cls):
@@ -130,7 +145,7 @@ class ComputeEnvironment(metaclass=ComputeEnvironmentType):
             else:
                 return cls.scheduler_type.is_present()
         else:
-            return re.match(cls.hostname_pattern, socket.getfqdn()) is not None
+            return re.match(cls.hostname_pattern, cls._cached_fqdn()) is not None
 
     @classmethod
     def get_scheduler(cls):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -44,12 +44,8 @@ logger = logging.getLogger(__name__)
 
 @lru_cache(maxsize=1)
 def _cached_fqdn():
-    """Returns the fully qualified domain name.
-
-    If called for the first time in a session, call socket.getfqdn
-    and cache the value. If called again, return the cached value.
-    Solves #339
-    """
+    """We cache this since fetching the fully qualified domain name can be
+    slow on macOS."""
     return socket.getfqdn()
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Adds `@lru_cache`ing of socket.getfqdn to reduce wait when it times out.

## Description
<!-- Describe your changes in detail -->
Thanks to Bradley for help along the way

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Resolves #339
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
