### PR TITLE
Evaluate run commands lazily.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -1984,8 +1984,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             )
             result["_operations_error"] = None
         except Exception as error:
-            msg = f"Error while getting operations status for job '{job}': '{error}'."
-            logger.debug(msg)
+            logger.debug(
+                "Error while getting operations status for job '%s': '%s'.", job, error
+            )
             if ignore_errors:
                 result["operations"] = {}
                 result["_operations_error"] = str(error)
@@ -1995,7 +1996,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             result["labels"] = sorted(set(self.labels(job)))
             result["_labels_error"] = None
         except Exception as error:
-            logger.debug(f"Error while determining labels for job '{job}': '{error}'.")
+            logger.debug(
+                "Error while determining labels for job '%s': '%s'.", job, error
+            )
             if ignore_errors:
                 result["labels"] = []
                 result["_labels_error"] = str(error)
@@ -2053,7 +2056,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         except NoSchedulerError:
             logger.debug("No scheduler available.")
         except RuntimeError as error:
-            logger.warning(f"Error occurred while querying scheduler: '{error}'.")
+            logger.warning("Error occurred while querying scheduler: '%s'.", error)
             if not ignore_errors:
                 raise
         else:
@@ -2128,7 +2131,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         try:
             result["labels"] = sorted(set(self.labels(job)))
         except Exception as error:
-            logger.debug(f"Error while determining labels for job '{job}': '{error}'.")
+            logger.debug(
+                "Error while determining labels for job '%s': '%s'.", job, error
+            )
             if ignore_errors:
                 result["labels"] = []
                 result["_labels_error"] = str(error)
@@ -2684,11 +2689,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         if errors:
             logger.warning(
-                "Some job status updates did not succeed due to errors. "
-                f"Number of unique errors: {len(errors)}. Use --debug to list all errors."
+                "Some job status updates did not succeed due to errors. Number "
+                "of unique errors: %i. Use --debug to list all errors.",
+                len(errors),
             )
             for i, error in enumerate(errors):
-                logger.debug(f"Status update error #{i + 1}: '{error}'")
+                logger.debug("Status update error #%i: '%s'", i + 1, error)
 
         if only_incomplete:
             # Remove jobs with no eligible operations from the status info
@@ -2916,12 +2922,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             for operation in operations:
                 self._execute_operation(operation, timeout, pretend)
         else:
-            logger.debug(f"Parallelized execution of {len(operations)} operation(s).")
+            logger.debug("Parallelized execution of %i operation(s).", len(operations))
             with contextlib.closing(
                 Pool(processes=cpu_count() if np < 0 else np)
             ) as pool:
                 logger.debug(
-                    f"Parallelized execution of {len(operations)} operation(s)."
+                    "Parallelized execution of %i operation(s).", len(operations)
                 )
                 try:
                     import pickle
@@ -3045,7 +3051,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             print(operation.cmd)
             return None
 
-        logger.info(f"Execute operation '{operation}'...")
+        logger.info("Execute operation '%s'...", operation)
         # Check if we need to fork for operation execution...
         if (
             # The 'fork' directive was provided and evaluates to True:
@@ -3059,15 +3065,17 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         ):
             # ... need to fork:
             logger.debug(
-                f"Forking to execute operation '{operation}' with "
-                f"cmd '{operation.cmd}'."
+                "Forking to execute operation '%s' with cmd '%s'.",
+                operation,
+                operation.cmd,
             )
             subprocess.run(operation.cmd, shell=True, timeout=timeout, check=True)
         else:
             # ... executing operation in interpreter process as function:
             logger.debug(
-                f"Executing operation '{operation}' with current interpreter "
-                f"process ({os.getpid()})."
+                "Executing operation '%s' with current interpreter process (%s).",
+                operation,
+                os.getpid(),
             )
             try:
                 self._operations[operation.name](*operation._jobs)
@@ -3321,7 +3329,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 )
 
             logger.info(
-                f"Executing {len(operations)} operation(s) (Pass #{i_pass:02d})..."
+                "Executing %i operation(s) (Pass #%02d)...",
+                len(operations),
+                i_pass,
             )
             self._run_operations(
                 operations, pretend=pretend, np=np, timeout=timeout, progress=progress
@@ -3544,8 +3554,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # with signac-flow unless additional environment information is
         # detected.
 
-        logger.info(f"Use environment '{env}'.")
-        logger.info(f"Set 'base_script={env.template}'.")
+        logger.info("Use environment '%s'.", env)
+        logger.info("Set 'base_script=%s'.", env.template)
         context["base_script"] = env.template
         context["environment"] = env
         context["id"] = _id
@@ -3661,9 +3671,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             if keys_unused:
                 logger.warning(
                     "Some of the keys provided as part of the directives were not used by "
-                    "the template script, including: {}".format(
-                        ", ".join(sorted(keys_unused))
-                    )
+                    "the template script, including: %s",
+                    ", ".join(sorted(keys_unused)),
                 )
             if pretend:
                 print(script)

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from contextlib import contextmanager
+from functools import lru_cache, partial
 from itertools import cycle, islice
 
 
@@ -200,3 +201,29 @@ def _to_hashable(obj):
         return _hashable_dict(obj)
     else:
         return obj
+
+
+def _cached_partial(func, /, *args, maxsize=None, **kwargs):
+    r"""Cache the results of a partial.
+
+    Useful for wrapping functions that must only be evaluated lazily, one time.
+
+    Parameters
+    ----------
+    func : callable
+        The function to call.
+    \*args
+        Positional arguments bound to the function.
+    maxsize : int
+        The maximum size of the LRU cache, or None for no limit. (Default value
+        = None)
+    \*\*kwargs
+        Keyword arguments bound to the function.
+
+    Returns
+    -------
+    callable
+        Function with bound arguments and cached return values.
+
+    """
+    return lru_cache(maxsize=maxsize)(partial(func, *args, **kwargs))

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -203,7 +203,7 @@ def _to_hashable(obj):
         return obj
 
 
-def _cached_partial(func, /, *args, maxsize=None, **kwargs):
+def _cached_partial(func, *args, maxsize=None, **kwargs):
     r"""Cache the results of a partial.
 
     Useful for wrapping functions that must only be evaluated lazily, one time.


### PR DESCRIPTION
## Description
Resolves #70. The command string evaluation for `FlowCmdOperation` was being done in several places where the command would never be executed (such as an ineligible job operation). Since we already have infrastructure for lazily evaluating commands, I took advantage of that to ensure that commands are evaluated as late as possible. This reduces the possibility of side effects and may also provide minor performance benefits. Furthermore, unevaluated command strings are fully-bound (no free parameters) and _should_ be side-effect-free (the user has no way to control many invocations of the callable command string will be performed), so it is safe to cache their results after the first evaluation.

This also resolves a separate problem I noted in logger messages, where eager evaluation of f-strings can cause property accesses and calls like `os.getpid()` that aren't strictly needed unless the message is going to be displayed. I only noticed this because there is a debug message that prints `operation.cmd` and thus triggers the lazy evaluation, even if the logger level is less verbose. You can read more about the problem and solution here: https://blog.pilosus.org/posts/2020/01/24/python-f-strings-in-logging/

## Motivation and Context
Resolves #70.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
