### PR TITLE
Add codecov support to CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,10 @@ jobs:
             python -m pip install --progress-bar off ${SIGNAC_VERSION}
             python -m pip install --progress-bar off -r requirements.txt
             python -m pip install --progress-bar off -r requirements-test.txt
-            python -m pip install --progress-bar off -U codecov mock
+            python -m pip install --progress-bar off -U codecov
 
       - run:
-          name: run tests
+          name: Run tests
           command: |
             . venv/bin/activate
             python -m pytest --cov=flow --cov-report=xml tests/ -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,17 +59,17 @@ jobs:
             mkdir -p ./venv
             python -m virtualenv ./venv
             . venv/bin/activate
-            pip install ${SIGNAC_VERSION}
-            pip install -r requirements.txt
-            pip install -r requirements-test.txt
-            pip install -U coverage mock
+            python -m pip install --progress-bar off ${SIGNAC_VERSION}
+            python -m pip install --progress-bar off -r requirements.txt
+            python -m pip install --progress-bar off -r requirements-test.txt
+            python -m pip install --progress-bar off -U codecov mock
 
       - run:
           name: run tests
           command: |
             . venv/bin/activate
-            coverage run --source=flow/ -m pytest -v tests/
-            coverage report -i --include="flow*"
+            python -m pytest --cov=flow --cov-report=xml tests/ -v
+            codecov
 
       - store_artifacts:
           path: test-reports

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
 click==7.1.2
+coverage==5.3
+pytest-cov==2.10.1
+pytest==6.2.1
 ruamel.yaml==0.16.12
-pytest==6.1.2


### PR DESCRIPTION
## Description
Adds codecov support to CI. This matches the implementation in signac, and I will merge this when tests pass and the Codecov service appears as expected.

## Motivation and Context
Having code coverage online is helpful for tracking whether new PRs are covered by existing tests.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
