### PR TITLE
Deprecate export_job_statuses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Changed
 
 - Command line interface for ``exec`` changed parameter name from ``jobid`` to ``job_id`` (#363).
 - Default environment for the University of Minnesota Mangi cluster changed from SLURM to Torque (#393).
+- Deprecated method ``export_job_statuses`` (#402).
 
 Fixed
 +++++

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -137,5 +137,5 @@ contributors:
   -
     family-names: Dave
     given-names: Shantanu
-    affiliation: "Jodhpur Institute Of Engineering and Technology"
+    affiliation: "Jodhpur Institute of Engineering and Technology"
 ...

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -134,4 +134,8 @@ contributors:
     given-names: Gabrielle
     orcid: "https://orcid.org/0000-0002-8041-4873"
     affiliation: "University of Michigan"
+  -
+    family-names: Dave
+    given-names: Shantanu
+    affiliation: "Jodhpur Institute Of Engineering and Technology"
 ...

--- a/flow/project.py
+++ b/flow/project.py
@@ -3541,6 +3541,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             help="Execute all operations in a single bundle in parallel.",
         )
 
+    @deprecated(deprecated_in="0.12", removed_in="0.14", current_version=__version__)
     def export_job_statuses(self, collection, statuses):
         "Export the job statuses to a database collection."
         for status in statuses:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Deprecated `export_job_statuses`
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes part of #395 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
