### PR TITLE
Use coverage configuration from setup.cfg.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            python -m pytest --cov=flow --cov-report=xml tests/ -v
+            python -m pytest --cov=flow --cov-config=setup.cfg --cov-report=xml tests/ -v
             codecov
 
       - store_artifacts:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,14 @@ select = E,F,W
 # Specify errors to ignore by default
 ignore = E123,E126,E226,E241,E704,W503,W504
 
+[coverage:run]
+branch = True
+concurrency = thread,multiprocessing
+parallel = True
+source = flow
+omit = 
+	*/flow/util/mistune/*.py
+
 [bumpversion:file:setup.py]
 
 [bumpversion:file:flow/version.py]


### PR DESCRIPTION
## Description
I fixed our coverage settings so that it reads the options from `setup.cfg`. The code coverage should exclude the vendored mistune code but it wasn't, because the options were being overlooked. I'll merge this after I verify the correct results show up on the Codecov website.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.