### PR TITLE
Optimization: use cached status everywhere.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Changed
 - ``CPUEnvironment`` and ``GPUEnvironment`` classes are deprecated (#381).
 - Docstrings are now written in `numpydoc style <https://numpydoc.readthedocs.io/en/latest/format.html>`__ (#392).
 - Default environment for the University of Minnesota Mangi cluster changed from SLURM to Torque (#393).
+- Improved internal caching of scheduler status (#410).
 
 Fixed
 +++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -4663,7 +4663,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         return {}
 
     def _eligible_for_submission(self, flow_group, jobs, cached_status):
-        """Check group eligibility for submission with a job/aggregate.
+        """Check group eligibility for submission with a job or aggregate.
 
         By default, an operation is eligible for submission when it
         is not considered active, that means already queued or running.

--- a/flow/project.py
+++ b/flow/project.py
@@ -4824,9 +4824,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         with self._potentially_buffered():
             names = args.operation_name if args.operation_name else None
             default_directives = self._get_default_directives()
+            cached_status = self._get_cached_status()
             operations = self._get_submission_operations(
                 aggregates,
                 default_directives,
+                cached_status,
                 names,
                 args.ignore_conditions,
                 args.ignore_conditions_on_execution,

--- a/flow/project.py
+++ b/flow/project.py
@@ -2033,17 +2033,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         """
         yield from self._expand_bundled_jobs(scheduler.jobs())
 
-    def _get_cached_status(self, cached_status=None):
+    def _get_cached_status(self):
         """Fetch all status information.
 
-        If the provided ``cached_status`` is not None, it is directly
-        returned. Otherwise, the project document key ``_status`` is
-        returned.
-
-        Parameters
-        ----------
-        cached_status : dict
-            Existing cached status information. (Default value = None)
+        The project document key ``_status`` is returned as a plain dict, or an
+        empty dict if no status information is present.
 
         Returns
         -------
@@ -2053,8 +2047,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             :class:`~.JobStatus`.
 
         """
-        if cached_status is not None:
-            return cached_status
         try:
             return self.document["_status"]()
         except KeyError:
@@ -2122,7 +2114,8 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         """
         # TODO: Add support for aggregates for this method.
-        cached_status = self._get_cached_status(cached_status)
+        if cached_status is None:
+            cached_status = self._get_cached_status()
         result = {}
         result["job_id"] = str(job)
         try:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1292,21 +1292,22 @@ class TestGroupProject(TestProjectBase):
 
     def test_directives_hierarchy(self):
         project = self.mock_project()
+        cached_status = project._get_cached_status()
         for job in project:
             # Test submit JobOperations
             job_ops = project._get_submission_operations(
-                aggregates=(job,),
+                aggregates=[(job,)],
                 default_directives=project._get_default_directives(),
-                cached_status={},
+                cached_status=cached_status,
                 names=["group2"],
             )
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 4 for job_op in job_ops]
             )
             job_ops = project._get_submission_operations(
-                aggregates=(job,),
+                aggregates=[(job,)],
                 default_directives=project._get_default_directives(),
-                cached_status={},
+                cached_status=cached_status,
                 names=["op3"],
             )
             assert all(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1295,34 +1295,46 @@ class TestGroupProject(TestProjectBase):
         cached_status = project._get_cached_status()
         for job in project:
             # Test submit JobOperations
-            job_ops = project._get_submission_operations(
-                aggregates=[(job,)],
-                default_directives=project._get_default_directives(),
-                cached_status=cached_status,
-                names=["group2"],
+            job_ops = list(
+                project._get_submission_operations(
+                    aggregates=[(job,)],
+                    default_directives=project._get_default_directives(),
+                    cached_status=cached_status,
+                    names=["group2"],
+                )
             )
+            assert len(job_ops) == 1
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 4 for job_op in job_ops]
             )
-            job_ops = project._get_submission_operations(
-                aggregates=[(job,)],
-                default_directives=project._get_default_directives(),
-                cached_status=cached_status,
-                names=["op3"],
+            job_ops = list(
+                project._get_submission_operations(
+                    aggregates=[(job,)],
+                    default_directives=project._get_default_directives(),
+                    cached_status=cached_status,
+                    names=["op3"],
+                )
             )
+            assert len(job_ops) == 1
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 1 for job_op in job_ops]
             )
             # Test run JobOperations
-            job_ops = project.groups["group2"]._create_run_job_operations(
-                project._entrypoint, project._get_default_directives(), (job,)
+            job_ops = list(
+                project.groups["group2"]._create_run_job_operations(
+                    project._entrypoint, project._get_default_directives(), (job,)
+                )
             )
+            assert len(job_ops) == 1
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 4 for job_op in job_ops]
             )
-            job_ops = project.groups["op3"]._create_run_job_operations(
-                project._entrypoint, project._get_default_directives(), (job,)
+            job_ops = list(
+                project.groups["op3"]._create_run_job_operations(
+                    project._entrypoint, project._get_default_directives(), (job,)
+                )
             )
+            assert len(job_ops) == 1
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 1 for job_op in job_ops]
             )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1262,7 +1262,11 @@ class TestGroupProject(TestProjectBase):
         project = self.mock_project()
         # For run mode single operation groups
         for job in project:
-            job_ops = project._get_submission_operations([(job,)], {})
+            job_ops = project._get_submission_operations(
+                aggregates=[(job,)],
+                default_directives={},
+                cached_status={},
+            )
             script = project._script(job_ops)
             if job.sp.b % 2 == 0:
                 assert str(job) in script
@@ -1291,13 +1295,19 @@ class TestGroupProject(TestProjectBase):
         for job in project:
             # Test submit JobOperations
             job_ops = project._get_submission_operations(
-                (job,), project._get_default_directives(), names=["group2"]
+                aggregates=(job,),
+                default_directives=project._get_default_directives(),
+                cached_status={},
+                names=["group2"],
             )
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 4 for job_op in job_ops]
             )
             job_ops = project._get_submission_operations(
-                (job,), project._get_default_directives(), names=["op3"]
+                aggregates=(job,),
+                default_directives=project._get_default_directives(),
+                cached_status={},
+                names=["op3"],
             )
             assert all(
                 [job_op.directives.get("omp_num_threads", 0) == 1 for job_op in job_ops]


### PR DESCRIPTION
## Description
This PR ensures that all status-fetching operations use a cached status dictionary.

The cached status information was already being used when printing status info, but not for submission.

I refactored the existing code to reduce duplication. I changed the APIs of several internal methods to *require* a `cached_status` argument, instead of allowing None.

## Motivation and Context
The benchmarks I was running locally kept fetching `project.document["_status"]` from the disk and converting from a synced dict to a plain dict. This loading and recursive conversion to a plain dict is slow for large workspaces and only needs to be called once at the beginning.

Also resolves #368.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md%23code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
