### PR TITLE
Remove reference to fakescheduler

### DIFF
--- a/tests/generate_template_reference_data.py
+++ b/tests/generate_template_reference_data.py
@@ -18,7 +18,7 @@ from test_project import redirect_stdout
 
 import flow
 import flow.environments
-from flow.scheduling.fakescheduler import FakeScheduler
+from flow.scheduling.fake_scheduler import FakeScheduler
 
 # Define a consistent submission name so that we can test that job names are
 # being correctly generated.

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -13,7 +13,7 @@ from test_project import redirect_stderr, redirect_stdout
 
 import flow
 import flow.environments
-from flow.scheduling.fakescheduler import FakeScheduler
+from flow.scheduling.fake_scheduler import FakeScheduler
 
 
 def _env_name(env):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
In #426 the module `flow/scheduling/fakescheduler.py` was renamed to `flow.scheduling.fake_scheduler.py` but there were some code referenced to the old module. This PR fixes that bug.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
