### PR TITLE
Fix _call_submit signature.

### DIFF
--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -125,7 +125,7 @@ class Scheduler(ABC):
         raise NotImplementedError()
 
 
-def _call_submit(self, submit_cmd, script, pretend):
+def _call_submit(submit_cmd, script, pretend):
     """Call submit command with a temporary script file.
 
     Parameters

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -157,7 +157,7 @@ def _call_submit(submit_cmd, script, pretend):
         with tempfile.NamedTemporaryFile() as tmp_submit_script:
             tmp_submit_script.write(str(script).encode("utf-8"))
             tmp_submit_script.flush()
-            submit_cmd += tmp_submit_script.name
+            submit_cmd.append(tmp_submit_script.name)
             try:
                 subprocess.check_output(submit_cmd, universal_newlines=True)
             except subprocess.CalledProcessError as error:


### PR DESCRIPTION
## Description
This fixes the signature of `_call_submit`, which was a mistake from refactoring #426.

## Motivation and Context
Fixes part of #437.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
