### PR TITLE
Remove `--test` option from `submit` CLI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -56,6 +56,7 @@ Removed
 - Removed the deprecated ``env`` argument from submission methods (#424).
 - ``flow.render_status.Renderer`` class has been removed. ``FlowProject.print_status`` no longer returns the renderer (#426).
 - Removed deprecated ``status.py`` module (#426).
+- Removed the ``--test`` argument from ``FlowProject.submit``. (#439).
 
 Version 0.11
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -56,7 +56,7 @@ Removed
 - Removed the deprecated ``env`` argument from submission methods (#424).
 - ``flow.render_status.Renderer`` class has been removed. ``FlowProject.print_status`` no longer returns the renderer (#426).
 - Removed deprecated ``status.py`` module (#426).
-- Removed the ``--test`` argument from ``FlowProject.submit``. (#439).
+- Removed the ``--test`` argument from ``FlowProject.submit`` (#439).
 
 Version 0.11
 ============

--- a/flow/project.py
+++ b/flow/project.py
@@ -3390,7 +3390,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         names=None,
         ignore_conditions=IgnoreConditions.NONE,
         ignore_conditions_on_execution=IgnoreConditions.NONE,
-        test=False,
     ):
         r"""Grabs eligible :class:`~._JobOperation`\ s from :class:`~.FlowGroup`\ s.
 
@@ -3416,10 +3415,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             Specify if preconditions and/or postconditions are to be ignored
             when determining eligibility after submitting. The default is
             :class:`IgnoreConditions.NONE`.
-        test : bool
-            If True, the submission will not update the scheduler status
-            before submission and the cached status will be used. (Default
-            value = False)
 
         Yields
         ------
@@ -3432,8 +3427,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         submission_groups = set(self._gather_flow_groups(names))
 
         # Fetch scheduler status
-        scheduler_info = self._query_scheduler_status() if not test else {}
-
+        scheduler_info = self._query_scheduler_status()
         for (
             scheduler_id,
             scheduler_status,
@@ -3802,7 +3796,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         parallel=False,
         force=False,
         walltime=None,
-        test=False,
         ignore_conditions=IgnoreConditions.NONE,
         ignore_conditions_on_execution=IgnoreConditions.NONE,
         **kwargs,
@@ -3837,10 +3830,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             Specify if preconditions and/or postconditions are to be ignored
             when determining eligibility after submitting. The default is
             :class:`IgnoreConditions.NONE`.
-        test : bool
-            If True, the submission will not update the scheduler status
-            before determining the operations to submit. The cached status
-            will still be used. (Default value = False)
         \*\*kwargs
             Additional keyword arguments forwarded to :meth:`~.ComputeEnvironment.submit`.
 
@@ -3871,8 +3860,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 "The ignore_conditions argument of FlowProject.run() "
                 "must be a member of class IgnoreConditions."
             )
-        if test:
-            kwargs["pretend"] = True
 
         # Gather all pending operations.
         with self._buffered():
@@ -3885,7 +3872,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 names,
                 ignore_conditions,
                 ignore_conditions_on_execution,
-                test=test,
             )
             # islice takes the first "num" elements from the generator, or all
             # items if num is None.
@@ -3922,11 +3908,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             "--force",
             action="store_true",
             help="Ignore all warnings and checks, just submit.",
-        )
-        parser.add_argument(
-            "--test",
-            action="store_true",
-            help="Do not interact with the scheduler, implies --pretend.",
         )
         parser.add_argument(
             "--ignore-conditions",
@@ -4788,8 +4769,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     def _main_submit(self, args):
         """Submit jobs to a scheduler."""
-        if args.test:
-            args.pretend = True
         kwargs = vars(args)
 
         # Select jobs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Remove the `test` option from `submit` CLI. Users should now use `submit --pretend` instead.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #419 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
