### PR TITLE
Fix labels and job count for projects with zero operations.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Fixed
 +++++
 
 - Support for multi-line ``@flow.cmd`` operations (#451, #453).
+- FlowProject status shows labels and correct number of jobs for projects with zero operations (#454, #460).
 
 Removed
 +++++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -2630,6 +2630,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # Add labels to the status information
         for job_label_data in job_labels:
             job_id = job_label_data["job_id"]
+            # If no status information existed, we need to set default values
             statuses.setdefault(job_id, {})
             statuses[job_id].setdefault("aggregate_id", job_id)
             statuses[job_id]["labels"] = job_label_data["labels"]

--- a/flow/project.py
+++ b/flow/project.py
@@ -2630,9 +2630,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # Add labels to the status information
         for job_label_data in job_labels:
             job_id = job_label_data["job_id"]
-            # If no status information existed, we need to set default values
+            # There is no status information if the project has no operations.
+            # If no status information exists for this job, we need to set
+            # default values.
             statuses.setdefault(job_id, {})
             statuses[job_id].setdefault("aggregate_id", job_id)
+            statuses[job_id].setdefault("groups", {})
             statuses[job_id]["labels"] = job_label_data["labels"]
 
         # If the dump_json variable is set, just dump all status info
@@ -2762,9 +2765,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 "eligible": False,
                 "scheduler_status": JobStatus.placeholder,
             }
-
-        for job in context["jobs"]:
-            job.setdefault("groups", {})
 
         for job in context["jobs"]:
             has_eligible_ops = any([v["eligible"] for v in job["groups"].values()])

--- a/flow/project.py
+++ b/flow/project.py
@@ -2631,6 +2631,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         for job_label_data in job_labels:
             job_id = job_label_data["job_id"]
             statuses.setdefault(job_id, {})
+            statuses[job_id].setdefault("aggregate_id", job_id)
             statuses[job_id]["labels"] = job_label_data["labels"]
 
         # If the dump_json variable is set, just dump all status info
@@ -2762,16 +2763,15 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             }
 
         for job in context["jobs"]:
-            if "groups" not in job:
-                continue
+            job.setdefault("groups", {})
+
+        for job in context["jobs"]:
             has_eligible_ops = any([v["eligible"] for v in job["groups"].values()])
             if not has_eligible_ops and not context["all_ops"]:
                 _add_placeholder_operation(job)
 
         op_counter = Counter()
         for job in context["jobs"]:
-            if "groups" not in job:
-                continue
             for group_name, group_status in job["groups"].items():
                 if group_name != "" and group_status["eligible"]:
                     op_counter[group_name] += 1


### PR DESCRIPTION
## Description
The new status fetching code did not correctly handle FlowProjects with zero operations. This resolves #454.

I don't really want to write tests for status checks in this PR but it should be done at some point.

I tested this manually by creating a project with no operations and with/without labels. I tested `python project.py status` with and without a bunch of flags, and it seems to be fine now.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
