### PR TITLE
Remove the run interface in operations.py

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Changed
 - Python 3.6 is only tested with oldest dependencies (#436).
 - Drop support for `tqdm <https://github.com/tqdm/tqdm>`__ versions older than `4.48.1` (#436, #440).
 - Drop support for `Jinja2 <https://palletsprojects.com/p/jinja/>`__ versions older than `2.10.0` (#436).
+- Deprecated operations.py method ``run`` (#463).
 
 Fixed
 +++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -61,7 +61,7 @@ Changed
 - Python 3.6 is only tested with oldest dependencies (#436).
 - Drop support for `tqdm <https://github.com/tqdm/tqdm>`__ versions older than `4.48.1` (#436, #440).
 - Drop support for `Jinja2 <https://palletsprojects.com/p/jinja/>`__ versions older than `2.10.0` (#436).
-- Deprecated operations.py method ``run`` (#463).
+- Deprecated ``operations.py`` method ``flow.run`` (#221, #463, #467).
 
 Fixed
 +++++

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -138,4 +138,8 @@ contributors:
     family-names: Dave
     given-names: Shantanu
     affiliation: "Jodhpur Institute of Engineering and Technology"
+  -
+    family-names: Gnabro
+    given-names: Ange-Desire
+    affiliation: ""
 ...

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -22,6 +22,8 @@ from signac import get_project
 from deprecation import deprecated
 from tqdm.auto import tqdm
 
+from . import __version__
+
 logger = logging.getLogger(__name__)
 
 

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -19,6 +19,7 @@ from functools import wraps
 from multiprocessing import Pool
 
 from signac import get_project
+from deprecation import deprecated
 from tqdm.auto import tqdm
 
 logger = logging.getLogger(__name__)
@@ -172,7 +173,7 @@ def _get_operations(include_private=False):
             if len(signature.args) == 1:
                 yield name
 
-
+@deprecated(deprecated_in="0.12", removed_in="0.14", current_version=__version__)
 def run(parser=None):
     """Access to the "run" interface of an operations module.
 

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -18,11 +18,11 @@ import sys
 from functools import wraps
 from multiprocessing import Pool
 
-from signac import get_project
 from deprecation import deprecated
+from signac import get_project
 from tqdm.auto import tqdm
 
-from . import __version__
+from .version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +174,7 @@ def _get_operations(include_private=False):
             signature = inspect.getfullargspec(obj)
             if len(signature.args) == 1:
                 yield name
+
 
 @deprecated(deprecated_in="0.12", removed_in="0.14", current_version=__version__)
 def run(parser=None):


### PR DESCRIPTION
Deprecated operations.py method ``run`` (#463)

## Description
- Add deprecation decorator into flow/operations.py
- Update contributors.yaml
- Update changelog.txt

## Motivation and Context
Unused interface

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).