### PR TITLE
Change default status_parallelization to "none".

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ Version 0.14
 Fixed
 +++++
 
-- Changed default value of ``status_parallelization`` to process, to avoid bugs in user code caused by thread parallelism (#486).
+- Changed default value of ``status_parallelization`` to none, to avoid bugs in user code caused by thread parallelism and overhead in process parallelism (#486).
 
 Removed
 +++++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,11 @@ Version 0.14
 [0.14.0] -- 2021-xx-xx
 ----------------------
 
+Fixed
++++++
+
+- Changed default value of ``status_parallelization`` to process, to avoid bugs in user code caused by thread parallelism (#486).
+
 Removed
 +++++++
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -2243,7 +2243,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         aggregates,
         err,
         ignore_errors,
-        status_parallelization="thread",
+        status_parallelization="process",
     ):
         """Fetch status for the provided aggregates / jobs.
 
@@ -2257,7 +2257,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             Fetch status even if querying the scheduler fails.
         status_parallelization : str
             Parallelization mode for fetching the status. Allowed values are
-            "thread", "process", or "none". (Default value = "thread")
+            "thread", "process", or "none". (Default value = "process")
 
         Returns
         -------

--- a/flow/project.py
+++ b/flow/project.py
@@ -2243,7 +2243,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         aggregates,
         err,
         ignore_errors,
-        status_parallelization="process",
+        status_parallelization="none",
     ):
         """Fetch status for the provided aggregates / jobs.
 
@@ -2257,7 +2257,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             Fetch status even if querying the scheduler fails.
         status_parallelization : str
             Parallelization mode for fetching the status. Allowed values are
-            "thread", "process", or "none". (Default value = "process")
+            "thread", "process", or "none". (Default value = "none")
 
         Returns
         -------

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -13,7 +13,7 @@ import_packaged_environments = boolean()
 status_performance_warn_threshold = float(default=0.2)
 show_traceback = boolean()
 eligible_jobs_max_lines = int(default=10)
-status_parallelization = string(default='thread')
+status_parallelization = string(default='process')
 """
 
 

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -13,7 +13,7 @@ import_packaged_environments = boolean()
 status_performance_warn_threshold = float(default=0.2)
 show_traceback = boolean()
 eligible_jobs_max_lines = int(default=10)
-status_parallelization = string(default='process')
+status_parallelization = string(default='none')
 """
 
 

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -325,7 +325,7 @@ def _run_cloudpickled_func(func, *args):
     return unpickled_func(*args)
 
 
-def _get_parallel_executor(parallelization="thread"):
+def _get_parallel_executor(parallelization="process"):
     """Get an executor for the desired parallelization strategy.
 
     This executor shows a progress bar while executing a function over an
@@ -340,7 +340,7 @@ def _get_parallel_executor(parallelization="thread"):
     ----------
     parallelization : str
         Parallelization mode. Allowed values are "thread", "process", or
-        "none". (Default value = "thread")
+        "none". (Default value = "process")
 
     Returns
     -------

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -325,7 +325,7 @@ def _run_cloudpickled_func(func, *args):
     return unpickled_func(*args)
 
 
-def _get_parallel_executor(parallelization="process"):
+def _get_parallel_executor(parallelization="none"):
     """Get an executor for the desired parallelization strategy.
 
     This executor shows a progress bar while executing a function over an
@@ -340,7 +340,7 @@ def _get_parallel_executor(parallelization="process"):
     ----------
     parallelization : str
         Parallelization mode. Allowed values are "thread", "process", or
-        "none". (Default value = "process")
+        "none". (Default value = "none")
 
     Returns
     -------


### PR DESCRIPTION
## Description
Changes status parallelization to "none".

Thread parallelism was causing bugs with GSD and deadlocks with signac 1.7 synced collections (those have been fixed).

Process parallelism is another viable strategy but the overhead in serialization/deserialization is currently too large to make the code performant unless the user's condition functions / labels are compute-bound.

Therefore, I have reverted to no parallelism for status checks. This seems to be performant enough on the project I've tested with around 2,000 jobs, 8 operations, and 15 condition functions.

@atravitz Can you verify that this fixes the issues you saw with GSD?

## Motivation and Context
The default status parallelization mode was changed from "process" to "thread" in a recent refactoring (#417). This caused some issues for user code. First it unveiled some problems with the locking mechanisms in signac (https://github.com/glotzerlab/signac/pull/529, https://github.com/glotzerlab/signac/pull/530), but also pointed to a lack of thread safety in [GSD](https://github.com/glotzerlab/gsd), which is a commonly used package with signac-flow. To avoid problems in user code, this PR changes the default back to "process" parallelization.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
