### PR TITLE
deprecating intermediate scheduler classes

### DIFF
--- a/flow/environment.py
+++ b/flow/environment.py
@@ -392,28 +392,43 @@ class SimpleSchedulerEnvironment(ComputeEnvironment):
     scheduler_type = SimpleScheduler
     template = "simple_scheduler.sh"
 
-
+@deprecated(
+    deprecated_in="0.16",
+    removed_in="0.17",
+    current_version=__version__,
+    details="PBSEnvironment has been deprecated, instead use DefaultPBSEnvironment",
+)
 class PBSEnvironment(ComputeEnvironment):
     """An environment with PBS scheduler."""
+    pass
 
-    scheduler_type = PBSScheduler
-    template = "pbs.sh"
-
-
+@deprecated(
+    deprecated_in="0.16",
+    removed_in="0.17",
+    current_version=__version__,
+    details="SlurmEnvironment has been deprecated, instead use DefaultSlurmEnvironment",
+)
 class SlurmEnvironment(ComputeEnvironment):
     """An environment with SLURM scheduler."""
 
-    scheduler_type = SlurmScheduler
-    template = "slurm.sh"
+    pass
 
-
+@deprecated(
+    deprecated_in="0.16",
+    removed_in="0.17",
+    current_version=__version__,
+    details="LSFEnvironment has been deprecated, instead use DefaultLSFEnvironment",
 class LSFEnvironment(ComputeEnvironment):
     """An environment with LSF scheduler."""
-
-    scheduler_type = LSFScheduler
-    template = "lsf.sh"
+    pass
 
 
+@deprecated(
+    deprecated_in="0.16",
+    removed_in="0.17",
+    current_version=__version__,
+    details="SlurmEnvironment has been deprecated.",
+)
 class NodesEnvironment(ComputeEnvironment):
     """A compute environment consisting of multiple compute nodes.
 
@@ -422,8 +437,11 @@ class NodesEnvironment(ComputeEnvironment):
     """
 
 
-class DefaultPBSEnvironment(NodesEnvironment, PBSEnvironment):
+class DefaultPBSEnvironment(ComputeEnvironment):
     """Default environment for clusters with a PBS scheduler."""
+
+    scheduler_type = PBSScheduler
+    template = "pbs.sh"
 
     @classmethod
     def add_args(cls, parser):
@@ -462,8 +480,11 @@ class DefaultTorqueEnvironment(DefaultPBSEnvironment):  # noqa: D101
     pass
 
 
-class DefaultSlurmEnvironment(NodesEnvironment, SlurmEnvironment):
+class DefaultSlurmEnvironment(ComputeEnvironment):
     """Default environment for clusters with a SLURM scheduler."""
+
+    scheduler_type = SlurmScheduler
+    template = "slurm.sh"
 
     @classmethod
     def add_args(cls, parser):
@@ -487,8 +508,11 @@ class DefaultSlurmEnvironment(NodesEnvironment, SlurmEnvironment):
         )
 
 
-class DefaultLSFEnvironment(NodesEnvironment, LSFEnvironment):
+class DefaultLSFEnvironment(ComputeEnvironment):
     """Default environment for clusters with a LSF scheduler."""
+
+    scheduler_type = LSFScheduler
+    template = "lsf.sh"
 
     @classmethod
     def add_args(cls, parser):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -392,6 +392,7 @@ class SimpleSchedulerEnvironment(ComputeEnvironment):
     scheduler_type = SimpleScheduler
     template = "simple_scheduler.sh"
 
+
 @deprecated(
     deprecated_in="0.16",
     removed_in="0.17",
@@ -400,7 +401,9 @@ class SimpleSchedulerEnvironment(ComputeEnvironment):
 )
 class PBSEnvironment(ComputeEnvironment):
     """An environment with PBS scheduler."""
+
     pass
+
 
 @deprecated(
     deprecated_in="0.16",
@@ -413,13 +416,16 @@ class SlurmEnvironment(ComputeEnvironment):
 
     pass
 
+
 @deprecated(
     deprecated_in="0.16",
     removed_in="0.17",
     current_version=__version__,
     details="LSFEnvironment has been deprecated, instead use DefaultLSFEnvironment",
+)
 class LSFEnvironment(ComputeEnvironment):
     """An environment with LSF scheduler."""
+
     pass
 
 
@@ -435,6 +441,8 @@ class NodesEnvironment(ComputeEnvironment):
     Each compute node is assumed to have a specific number of compute units,
     e.g., CPUs.
     """
+
+    pass
 
 
 class DefaultPBSEnvironment(ComputeEnvironment):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -394,8 +394,8 @@ class SimpleSchedulerEnvironment(ComputeEnvironment):
 
 
 @deprecated(
-    deprecated_in="0.16",
-    removed_in="0.17",
+    deprecated_in="0.14",
+    removed_in="0.15",
     current_version=__version__,
     details="PBSEnvironment has been deprecated, instead use DefaultPBSEnvironment",
 )
@@ -406,8 +406,8 @@ class PBSEnvironment(ComputeEnvironment):
 
 
 @deprecated(
-    deprecated_in="0.16",
-    removed_in="0.17",
+    deprecated_in="0.14",
+    removed_in="0.15",
     current_version=__version__,
     details="SlurmEnvironment has been deprecated, instead use DefaultSlurmEnvironment",
 )
@@ -418,8 +418,8 @@ class SlurmEnvironment(ComputeEnvironment):
 
 
 @deprecated(
-    deprecated_in="0.16",
-    removed_in="0.17",
+    deprecated_in="0.14",
+    removed_in="0.15",
     current_version=__version__,
     details="LSFEnvironment has been deprecated, instead use DefaultLSFEnvironment",
 )
@@ -430,10 +430,10 @@ class LSFEnvironment(ComputeEnvironment):
 
 
 @deprecated(
-    deprecated_in="0.16",
-    removed_in="0.17",
+    deprecated_in="0.14",
+    removed_in="0.15",
     current_version=__version__,
-    details="SlurmEnvironment has been deprecated.",
+    details="NodesEnvironment has been deprecated.",
 )
 class NodesEnvironment(ComputeEnvironment):
     """A compute environment consisting of multiple compute nodes.


### PR DESCRIPTION


## Description
Addresses request for deprecation in issue #492 

## Motivation and Context
Improves code readability by removing unnecessary intermediate classes.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
