### PR TITLE
Make LSF / SLURM scheduler detection consistent with PBS.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Changed
 +++++++
 
 - Renamed TorqueEnvironment and related classes to PBSEnvironment (#491).
+- LSF and SLURM schedulers will appear to be present if the respective commands ``bjobs -V`` or ``sbatch --version`` exit with a non-zero error code (#498).
 
 Fixed
 +++++

--- a/flow/scheduling/lsf.py
+++ b/flow/scheduling/lsf.py
@@ -160,6 +160,8 @@ class LSFScheduler(Scheduler):
         """Return True if an LSF scheduler is detected."""
         try:
             subprocess.check_output(["bjobs", "-V"], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            return True
         except OSError:
             return False
         else:

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -154,6 +154,8 @@ class SlurmScheduler(Scheduler):
         """Return True if a SLURM scheduler is detected."""
         try:
             subprocess.check_output(["sbatch", "--version"], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            return True
         except OSError:
             return False
         else:


### PR DESCRIPTION
## Description
See question in issue #53. Either we should accept this PR and make the scheduling behavior consistent with the PBS changes adopted in PR #54, or we should make `is_present` return `False` for all schedulers if the scheduler version cannot be determined.

Regardless of whether the result is `True` or `False`, this PR should ensure that all schedulers catch `subprocess.CalledProcessError`. If they don't, the resulting user message raised by `flow.get_environment()` is potentially confusing.

Pros/cons of each possible behavior:

If we make `is_present` return False when the exception is caught, then we break the behavior mentioned in https://github.com/glotzerlab/signac-flow/issues/53 where compute nodes cannot submit jobs (only login nodes), which would also likely break important parts of signac-flow.

If we make `is_present` return True when the exception is caught, then we run the risk of detecting the wrong kind of environment. However, this is already a risk we run if two scheduler executables happen to exit with code 0 when asked for their version, regardless of whether both actually work.

## Motivation and Context
Related to a question from @klywang on Andes, which incorrectly detects `bjobs` (LSF) even though it uses SLURM and not LSF. `bjobs -V` fails to execute and raises a confusing `subprocess.CalledProcessError` that the user does not expect, because it fails when querying the LSF scheduler (which isn't even the right scheduler for the Andes system).

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
