### PR TITLE
Only write known JobStatus values.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Changed
 
 - Renamed TorqueEnvironment and related classes to PBSEnvironment (#491).
 - LSF and SLURM schedulers will appear to be present if the respective commands ``bjobs -V`` or ``sbatch --version`` exit with a non-zero error code (#498).
+- Only known JobStatus values will be written to the project document, to save space and writing time (#503).
 
 Fixed
 +++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -1896,14 +1896,23 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         try:
             yield status_update
         finally:
-            if status_update:
-                status_update = {
-                    key: int(value) for key, value in status_update.items()
-                }
-                if "_status" in self.document:
-                    self.document["_status"].update(status_update)
-                else:
-                    self.document["_status"] = status_update
+            if not status_update:
+                return
+
+            status_update = {key: int(value) for key, value in status_update.items()}
+            if "_status" in self.document:
+                disk_status = self.document["_status"]()
+            else:
+                disk_status = {}
+            disk_status.update(status_update)
+
+            # Filter out JobStatus.unknown == 1 before writing to disk, to save
+            # space and reduce the write time.
+            disk_status = {
+                key: value for key, value in disk_status.items() if value != 1
+            }
+
+            self.document["_status"] = disk_status
 
     def _generate_selected_aggregate_groups(
         self,

--- a/flow/project.py
+++ b/flow/project.py
@@ -1906,10 +1906,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 disk_status = {}
             disk_status.update(status_update)
 
-            # Filter out JobStatus.unknown == 1 before writing to disk, to save
+            # Filter out JobStatus.unknown before writing to disk, to save
             # space and reduce the write time.
             disk_status = {
-                key: value for key, value in disk_status.items() if value != 1
+                key: value
+                for key, value in disk_status.items()
+                if value != int(JobStatus.unknown)
             }
 
             self.document["_status"] = disk_status

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1228,6 +1228,12 @@ class TestExecutionProject(TestProjectBase):
             next_op = list(project._next_operations([(job,)]))[0]
             assert next_op.name == "op1"
             assert next_op._jobs == (job,)
+
+        cached_status = project._get_cached_scheduler_status()
+        for job in project:
+            for next_op in project._next_operations([(job,)]):
+                assert next_op.id not in cached_status
+
         with redirect_stderr(StringIO()):
             project.submit()
         assert len(list(MockScheduler.jobs())) == num_jobs_submitted


### PR DESCRIPTION
## Description
This PR skips writing job-operations with `unknown` status to disk, by performing an update of the current status in-memory and then filtering out all job-operations with `unknown` status before writing to the project document.

## Motivation and Context
For most projects, the vast majority of job-operations have status `JobStatus.unknown == 1`.
For example, my current project document is 78 MB and it's _all_ unknown statuses.
I am currently seeing some challenges with scalability caused by the size of the project document when the `_status` key just holds a huge dictionary with long keys and values equal to 1, like `'training_dat/ec1a26016d5d4c941273675e0cc28cd1/mpb_plot_dos/96dad330426b7160a70b44af0e4c99a2': 1`. There should be no effect on the correctness of submission or status checks, because `JobStatus.unknown` is already the default value when no value is present.

This PR sped up my status check from 46.4 seconds to 39.4 seconds. 7.0 seconds = 15% faster. 🏎️
The new project document is only 15 bytes, instead of 78 MB.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
