### PR TITLE
Fix: don't catch SubmitErrors, show to user.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,17 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.15
+============
+
+[0.15.0] -- 2021-xx-xx
+----------------------
+
+Fixed
++++++
+
+- Errors raised during submission were not being shown to users (#517, #518).
+
 Version 0.14
 ============
 

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -110,7 +110,6 @@ def add_path_to_environment_pythonpath(path):
             yield
         finally:
             os.environ["PYTHONPATH"] = pythonpath
-            pass
     else:
         try:
             # The PYTHONPATH was previously not set, set to current working directory.


### PR DESCRIPTION
## Description
The cached status update context manager was hiding exceptions from users. I believe that I might have introduced this bug in a previous pull request, because I didn't know that `finally` clauses containing `return` statements would clear exceptions.

I fixed the problem:
- Remove `return` from `finally` clause to ensure that exceptions are raised.
- Add test that SubmitErrors are raised to the user.

Further explanation: https://stackoverflow.com/questions/61264374/using-tryfinally-without-except-never-generates-any-error

## Motivation and Context
Fixes #517.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
