### PR TITLE
Fixed dependency flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Fixed
 +++++
 
 - Errors raised during submission were not being shown to users (#517, #518).
+- Fixed dependency flag for SLURM submissions (#530)
 
 Version 0.14
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,7 +30,7 @@ Fixed
 +++++
 
 - Errors raised during submission were not being shown to users (#517, #518).
-- Fixed dependency flag for SLURM submissions (#530)
+- Fixed dependency flag for SLURM submissions (#530).
 
 Version 0.14
 ============

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -140,9 +140,7 @@ class SlurmScheduler(Scheduler):
         submit_cmd = self.submit_cmd + flags
 
         if after is not None:
-            submit_cmd.extend(
-                ["-W", '-d afterany:{}'.format(after.split(".")[0])]
-            )
+            submit_cmd.extend(["-W", "-d afterany:{}".format(after.split(".")[0])])
 
         if hold:
             submit_cmd += ["--hold"]

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -140,7 +140,7 @@ class SlurmScheduler(Scheduler):
         submit_cmd = self.submit_cmd + flags
 
         if after is not None:
-            submit_cmd.extend(["-W", "-d", "afterany:{}".format(after)])
+            submit_cmd.extend(["-W", "-d", f"afterany:{after}"])
 
         if hold:
             submit_cmd += ["--hold"]

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -140,7 +140,7 @@ class SlurmScheduler(Scheduler):
         submit_cmd = self.submit_cmd + flags
 
         if after is not None:
-            submit_cmd.extend(["-W", "-d afterany:{}".format(after.split(".")[0])])
+            submit_cmd.extend(["-W", "-d", "afterany:{}".format(after.split(".")[0])])
 
         if hold:
             submit_cmd += ["--hold"]

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -140,7 +140,7 @@ class SlurmScheduler(Scheduler):
         submit_cmd = self.submit_cmd + flags
 
         if after is not None:
-            submit_cmd.extend(["-W", "-d", f"afterany:{after}"])
+            submit_cmd.extend(["-W", "-d", f"afterok:{after}"])
 
         if hold:
             submit_cmd += ["--hold"]

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -141,7 +141,7 @@ class SlurmScheduler(Scheduler):
 
         if after is not None:
             submit_cmd.extend(
-                ["-W", 'depend="afterany:{}"'.format(after.split(".")[0])]
+                ["-W", '-d afterany:{}'.format(after.split(".")[0])]
             )
 
         if hold:

--- a/flow/scheduling/slurm.py
+++ b/flow/scheduling/slurm.py
@@ -140,7 +140,7 @@ class SlurmScheduler(Scheduler):
         submit_cmd = self.submit_cmd + flags
 
         if after is not None:
-            submit_cmd.extend(["-W", "-d", "afterany:{}".format(after.split(".")[0])])
+            submit_cmd.extend(["-W", "-d", "afterany:{}".format(after)])
 
         if hold:
             submit_cmd += ["--hold"]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1609,12 +1609,6 @@ class TestProjectSubmitOptions(TestProjectBase):
         )
     )
 
-    @pytest.fixture(autouse=True)
-    def setup_main_interface(self, request):
-        self.project = self.mock_project()
-        os.chdir(self._tmp_dir.name)
-        request.addfinalizer(self.switch_to_cwd)
-
     @pytest.mark.parametrize(
         "env,after_cmd",
         [

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1601,6 +1601,76 @@ class TestProjectDagDetection(TestProjectBase):
         assert adj == adj_correct
 
 
+class TestProjectSubmitOptions(TestProjectBase):
+    project_class = _TestProject
+    entrypoint = dict(
+        path=os.path.realpath(
+            os.path.join(os.path.dirname(__file__), "define_test_project.py")
+        )
+    )
+
+    @pytest.fixture(autouse=True)
+    def setup_main_interface(self, request):
+        self.project = self.mock_project()
+        os.chdir(self._tmp_dir.name)
+        request.addfinalizer(self.switch_to_cwd)
+
+    @pytest.mark.parametrize(
+        "env,after_cmd",
+        [
+            ("DefaultSlurmEnvironment", "sbatch -W -d afterok:{}"),
+            ("DefaultPBSEnvironment", 'qsub -W depend="afterok:{}"'),
+            ("DefaultLSFEnvironment", 'bsub -w "done({})"'),
+        ],
+    )
+    def test_main_submit_after(self, env, after_cmd, monkeypatch):
+        # Ensure that the --after flag is included in submission commands.
+        # Force the detected environment via the SIGNAC_FLOW_ENVIRONMENT
+        # environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", env)
+        project = self.mock_project()
+        assert len(project)
+        # This monkeypatch prevents failures due to lacking the scheduler
+        # executable for checking existing scheduler jobs before submitting.
+        monkeypatch.setattr(
+            project, "_query_scheduler_status", lambda *args, **kwargs: {}
+        )
+
+        after_value = "123"
+        submit_output = StringIO()
+        with redirect_stdout(submit_output):
+            project.submit(names=["op1"], pretend=True, num=1, after=after_value)
+        submit_output = submit_output.getvalue()
+        assert ("# Submit command: " + after_cmd.format(after_value)) in submit_output
+
+    @pytest.mark.parametrize(
+        "env,hold_cmd",
+        [
+            ("DefaultSlurmEnvironment", "sbatch --hold"),
+            ("DefaultPBSEnvironment", "qsub -h"),
+            ("DefaultLSFEnvironment", "bsub -H"),
+        ],
+    )
+    def test_main_submit_hold(self, env, hold_cmd, monkeypatch):
+        # Ensure that the --hold flag is included in submission commands.
+        # Force the detected environment via the SIGNAC_FLOW_ENVIRONMENT
+        # environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", env)
+        project = self.mock_project()
+        assert len(project)
+        # This monkeypatch prevents failures due to lacking the scheduler
+        # executable for checking existing scheduler jobs before submitting.
+        monkeypatch.setattr(
+            project, "_query_scheduler_status", lambda *args, **kwargs: {}
+        )
+
+        submit_output = StringIO()
+        with redirect_stdout(submit_output):
+            project.submit(names=["op1"], pretend=True, num=1, hold=True)
+        submit_output = submit_output.getvalue()
+        assert ("# Submit command: " + hold_cmd) in submit_output
+
+
 # Tests for multiple operation groups or groups with options
 class TestGroupProject(TestProjectBase):
     project_class = _TestProject


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Changed submission flag from `depend="afterany:{job_id}"` to `-d afterany:{job_id}` for SLURM.

Maybe we should make a PR to check other schedulers as well.

Checked on GreatLakes. Tried to submit with one and two job dependencies and it worked.

## Motivation and Context
Fixes #530 

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
