### PR TITLE
Require a scheduler to submit, even with --pretend enabled.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Changed
 
 - Jinja templates are indented for easier reading (#461, #495).
 - ``flow.directives`` is deprecated in favor of ``flow.FlowProject.operation.with_directives`` (#309, #502).
+- All environments require a scheduler in order to submit, even in pretend mode (#533).
 
 Fixed
 +++++

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Changed
 - Jinja templates are indented for easier reading (#461, #495).
 - ``flow.directives`` is deprecated in favor of ``flow.FlowProject.operation.with_directives`` (#309, #502).
 - All environments require a scheduler in order to submit, even in pretend mode (#533).
+- Submitting in pretend mode will show additional scheduler command information (#533).
 
 Fixed
 +++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -3609,7 +3609,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         flags=None,
         force=False,
         template="script.sh",
-        pretend=False,
         show_template_help=False,
         **kwargs,
     ):

--- a/flow/project.py
+++ b/flow/project.py
@@ -3630,9 +3630,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         template : str
             The name of the template file to be used to generate the submission
             script. (Default value = "script.sh")
-        pretend : bool
-            Do not actually submit, but only print the submission script to screen. Useful
-            for testing the submission workflow. (Default value = False)
         show_template_help : bool
             Show information about available template variables and filters and
             exit. (Default value = False)
@@ -3692,13 +3689,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                     "the template script, including: %s",
                     ", ".join(sorted(keys_unused)),
                 )
-            if pretend:
-                print(script)
-
-            else:
-                return self._environment.submit(
-                    _id=_id, script=script, flags=flags, **kwargs
-                )
+            return self._environment.submit(
+                _id=_id, script=script, flags=flags, **kwargs
+            )
 
     def submit(
         self,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -193,7 +193,6 @@ class TestProjectBase:
         # Determine path to project module and construct command.
         fn_script = inspect.getsourcefile(type(self.project))
         _cmd = f"python {fn_script} {subcmd}"
-
         try:
             with add_path_to_environment_pythonpath(os.path.abspath(self.cwd)):
                 with switch_to_directory(self.project.root_directory()):
@@ -1522,7 +1521,10 @@ class TestDirectivesProjectMainInterface(TestProjectBase):
         os.chdir(self._tmp_dir.name)
         request.addfinalizer(self.switch_to_cwd)
 
-    def test_main_submit_walltime_with_directive(self):
+    def test_main_submit_walltime_with_directive(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
         output = self.call_subcmd(
             "submit -o op_walltime --pretend --template slurm.sh",
@@ -1530,21 +1532,30 @@ class TestDirectivesProjectMainInterface(TestProjectBase):
         ).decode("utf-8")
         assert "#SBATCH -t 01:00:00" in output
 
-    def test_main_submit_walltime_no_directive(self):
+    def test_main_submit_walltime_no_directive(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
         output = self.call_subcmd(
             "submit -o op_walltime_2 --pretend --template slurm.sh", subprocess.STDOUT
         ).decode("utf-8")
         assert "#SBATCH -t" not in output
 
-    def test_main_submit_walltime_with_groups(self):
+    def test_main_submit_walltime_with_groups(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
         output = self.call_subcmd(
             "submit -o walltimegroup --pretend --template slurm.sh", subprocess.STDOUT
         ).decode("utf-8")
         assert "#SBATCH -t 03:00:00" in output
 
-    def test_main_submit_walltime_serial(self):
+    def test_main_submit_walltime_serial(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
         job_id = next(iter(self.project)).get_id()
         output = self.call_subcmd(
@@ -1554,7 +1565,10 @@ class TestDirectivesProjectMainInterface(TestProjectBase):
         ).decode("utf-8")
         assert "#SBATCH -t 03:00:00" in output
 
-    def test_main_submit_walltime_parallel(self):
+    def test_main_submit_walltime_parallel(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
         job_id = next(iter(self.project)).get_id()
         output = self.call_subcmd(
@@ -1926,7 +1940,10 @@ class TestGroupProjectMainInterface(TestProjectBase):
             else:
                 assert not job.isfile("world.txt")
 
-    def test_main_submit(self):
+    def test_main_submit(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         project = self.mock_project()
         assert len(project)
         # Assert that correct output for group submission is given
@@ -2069,7 +2086,10 @@ class TestAggregationProjectMainInterface(TestAggregatesProjectBase):
 
         assert "1 and 2" in run_output
 
-    def test_main_submit(self):
+    def test_main_submit(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         project = self.mock_project()
         assert len(project)
 
@@ -2096,7 +2116,10 @@ class TestAggregationGroupProjectMainInterface(TestAggregatesProjectBase):
             assert job.doc.op2
             assert job.doc.op3
 
-    def test_main_submit(self):
+    def test_main_submit(self, monkeypatch):
+        # Force the submitting subprocess to use the TestEnvironment and
+        # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
+        monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         project = self.mock_project()
         assert len(project)
 


### PR DESCRIPTION
## Description
This PR forces all "pretend" submissions to go through a scheduler. Environments without a scheduler such as `StandardEnvironment` are no longer able to submit in pretend mode. It should be possible to achieve similar output using the `run --pretend` functionality (environments without schedulers can still use `run`, just not `submit`).

For testing purposes, the `TestEnvironment` uses `FakeScheduler` which always just prints the submission script. Use the `TestEnvironment` with the environment variable `SIGNAC_FLOW_ENVIRONMENT="TestEnvironment"`.

## Motivation and Context
Currently users can call `python project.py submit --pretend` even when using the `StandardEnvironment`, which renders the base template with the output script. However, this isn't very useful and the current code circumvents the use of the schedulers' support for `pretend=True`, which can provide additional information such as the submission command that would be used without `--pretend`.

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
