### PR TITLE
Add tests for the flow CLI.

### DIFF
--- a/flow/__main__.py
+++ b/flow/__main__.py
@@ -76,9 +76,10 @@ def main():
         type=str,
         nargs="?",
         default="project",
-        help="Name of the flow project module to initialize. "
-        "This name will also be used to initialize a signac project in case that "
-        "no project was initialized prior to calling 'init'.",
+        help="Name of the FlowProject module to initialize. "
+        "This name will also be used to initialize a signac project if "
+        "no signac project was initialized prior to calling 'init'. "
+        "Default value: 'project'.",
     )
     parser_init.add_argument(
         "-t",
@@ -86,7 +87,7 @@ def main():
         type=str,
         choices=tuple(sorted(template.TEMPLATES)),
         default="minimal",
-        help="Specify a specific to template to use.",
+        help="Specify a template to use. Default value: 'minimal'.",
     )
 
     if "--version" in sys.argv:

--- a/flow/template.py
+++ b/flow/template.py
@@ -113,7 +113,7 @@ def init(alias=None, template=None, root=None):
                 error_message += f"a file named '{fn}' already exists!"
             else:
                 error_message += f"'{error}'."
-            raise RuntimeError(error_message)
+            raise OSError(error_message)
         else:
             files_created.append(fn)
             print(f"Created file '{fn}'.", file=sys.stderr)

--- a/flow/template.py
+++ b/flow/template.py
@@ -106,16 +106,14 @@ def init(alias=None, template=None, root=None):
             with open(fn, "x") as fw:
                 fw.write(code + "\n")
         except OSError as error:
+            error_message = (
+                f"Error while creating FlowProject module with name '{alias}': "
+            )
             if error.errno == errno.EEXIST:
-                logger.error(
-                    f"Error while trying to initialize flow project with alias '{alias}', "
-                    f"a file named '{fn}' already exists!"
-                )
+                error_message += f"a file named '{fn}' already exists!"
             else:
-                logger.error(
-                    f"Error while trying to initialize flow project with alias '{alias}': "
-                    f"'{error}'."
-                )
+                error_message += f"'{error}'."
+            raise RuntimeError(error_message)
         else:
             files_created.append(fn)
             print(f"Created file '{fn}'.", file=sys.stderr)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -74,7 +74,7 @@ class TestCLI:
         assert str(signac.get_project()) == "my_project"
         assert os.path.exists("my_project.py")
 
-    def test_init_flowproject_again(self):
+    def test_init_flowproject_fail_if_exists(self):
         self.call("python -m flow init".split())
         assert str(signac.get_project()) == "project"
         assert os.path.exists("project.py")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2021 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+import os
+import subprocess
+from tempfile import TemporaryDirectory
+
+import pytest
+import signac
+
+import flow
+
+
+class ExitCodeError(RuntimeError):
+    pass
+
+
+class TestCLI:
+    @pytest.fixture(autouse=True)
+    def setUp(self, request):
+        pythonpath = os.environ.get("PYTHONPATH")
+        if pythonpath is None:
+            pythonpath = [os.getcwd()]
+        else:
+            pythonpath = [os.getcwd()] + pythonpath.split(":")
+        os.environ["PYTHONPATH"] = ":".join(pythonpath)
+        self.tmpdir = TemporaryDirectory(prefix="signac-flow_")
+        request.addfinalizer(self.tmpdir.cleanup)
+        self.cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+        request.addfinalizer(self.return_to_cwd)
+
+    def return_to_cwd(self):
+        os.chdir(self.cwd)
+
+    def call(self, command, input=None, shell=False, error=False, raise_error=True):
+        p = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=shell,
+        )
+        if input:
+            p.stdin.write(input.encode())
+        out, err = p.communicate()
+        if p.returncode != 0 and raise_error:
+            raise ExitCodeError(f"STDOUT='{out}' STDERR='{err}'")
+        return err.decode() if error else out.decode()
+
+    def test_print_usage(self):
+        with pytest.raises(ExitCodeError):
+            self.call("python -m flow".split())
+
+        out = self.call("python -m flow".split(), raise_error=False)
+        assert "usage:" in out
+
+    def test_version(self):
+        out = self.call("python -m flow --version".split())
+        assert f"signac-flow {flow.__version__}" in out
+
+    def test_help(self):
+        out = self.call("python -m flow --help".split())
+        assert "positional arguments:" in out
+        assert "optional arguments:" in out
+
+    def test_init_flowproject(self):
+        self.call("python -m flow init".split())
+        assert str(signac.get_project()) == "project"
+        assert os.path.exists("project.py")
+
+    def test_init_flowproject_alias(self):
+        self.call("python -m flow init my_project".split())
+        assert str(signac.get_project()) == "my_project"
+        assert os.path.exists("my_project.py")
+
+    def test_init_flowproject_again(self):
+        self.call("python -m flow init".split())
+        assert str(signac.get_project()) == "project"
+        assert os.path.exists("project.py")
+        with pytest.raises(ExitCodeError):
+            self.call("python -m flow init".split())
+
+    @pytest.mark.parametrize("template", flow.template.TEMPLATES)
+    def test_init_flowproject_template(self, template):
+        self.call(f"python -m flow init -t {template}".split())
+        assert str(signac.get_project()) == "project"
+        assert os.path.exists("project.py")


### PR DESCRIPTION
## Description
Adds tests for the `flow` CLI.

I also made some minor tweaks to the behavior and docs of `flow init`. Now it raises errors and has a nonzero exit code on failure, instead of just printing the message describing failure and exiting with code zero.

## Motivation and Context
This mirrors the [CLI tests in signac](https://github.com/glotzerlab/signac/blob/master/tests/test_shell.py) and was created to assist with the testing process for #534.

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
