### PR TITLE
Permit groups with >1 operation in status check.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -2398,9 +2398,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         def compute_status(data):
             scheduler_id, scheduler_status, aggregate_id, aggregate, group = data
-            # Only single-operation groups are supported for status fetching
-            assert len(group.operations) == 1
-
             status = {}
             error_text = None
             try:
@@ -2437,7 +2434,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 self._generate_selected_aggregate_groups_with_status(
                     scheduler_info=scheduler_info,
                     selected_aggregates=aggregates,
-                    selected_groups=single_operation_groups,
                 )
             )
             status_results = parallel_executor(


### PR DESCRIPTION
## Description
While looking into #547 and discussing with @b-butler, I found out that the refactors of the status code from #417 might have broken group status updates.

Here's the output I get with these changes on commit bbeabe1ec83d36268fee16901645ce027a012cb5 (compare with output in #547, which does not show `band_path_group` or `dos_group`).
![image](https://user-images.githubusercontent.com/3943761/123553990-a838af80-d743-11eb-85d9-00ebfe8b0b30.png)

## Motivation and Context
Partially fixes #547.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
