### PR TITLE
Update directives docs.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,17 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.16
+============
+
+[0.16.0] -- 2021-xx-xx
+----------------------
+
+Changed
++++++++
+
+- Improved documentation of directives (#554).
+
 Version 0.15
 ============
 

--- a/flow/directives.py
+++ b/flow/directives.py
@@ -607,3 +607,11 @@ For example:
         pass
 
 """
+
+
+def _document_directive(directive):
+    """Dynamically generates documentation for a directive."""
+    name = directive._name
+    name = name.replace("_", r"\_")
+    doc = directive.__doc__
+    return f"**{name}**\n\n{doc}"

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -15,10 +15,7 @@ import logging
 from functools import wraps
 from textwrap import indent
 
-from deprecation import deprecated
-
 from .environment import ComputeEnvironment
-from .version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -111,18 +108,16 @@ def with_job(func):
     return decorated
 
 
-@deprecated(
-    deprecated_in="0.15",
-    removed_in="1.0",
-    current_version=__version__,
-    details="Use FlowProject.operation.with_directives",
-)
 class directives:
     """Decorator for operation functions to provide additional execution directives.
 
     Directives can for example be used to provide information about required resources
     such as the number of processes required for execution of parallelized operations.
-    For more information, read about :ref:`signac-docs:directives`.
+    For more information, read about :ref:`signac-docs:cluster_submission_directives`.
+
+    .. deprecated:: 0.15
+        This decorator is deprecated and will be removed in 1.0.
+        Use :class:`FlowProject.operation.with_directives` instead.
 
     """
 

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -15,6 +15,7 @@ import logging
 from functools import wraps
 from textwrap import indent
 
+from .directives import _document_directive
 from .environment import ComputeEnvironment
 
 logger = logging.getLogger(__name__)
@@ -149,14 +150,6 @@ class directives:
         directives.update(self.kwargs)
         setattr(func, "_flow_directives", directives)
         return func
-
-
-# Remove when @flow.directives is removed
-def _document_directive(directive):
-    name = directive._name
-    name = name.replace("_", r"\_")
-    doc = directive.__doc__
-    return f"**{name}**\n\n{doc}"
 
 
 # Remove when @flow.directives is removed

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -151,6 +151,7 @@ class directives:
         return func
 
 
+# Remove when @flow.directives is removed
 def _document_directive(directive):
     name = directive._name
     name = name.replace("_", r"\_")
@@ -158,6 +159,7 @@ def _document_directive(directive):
     return f"**{name}**\n\n{doc}"
 
 
+# Remove when @flow.directives is removed
 _directives_to_document = (
     ComputeEnvironment._get_default_directives()._directive_definitions.values()
 )

--- a/flow/project.py
+++ b/flow/project.py
@@ -45,6 +45,7 @@ from .aggregates import (
     aggregator,
     get_aggregate_id,
 )
+from .directives import _document_directive
 from .environment import ComputeEnvironment, get_environment
 from .errors import (
     ConfigKeyError,
@@ -711,12 +712,12 @@ class FlowGroupEntry:
         Parameters
         ----------
         directives : dict
-            Directives to use for execution.
+            Directives to use for resource requests and execution.
 
         Returns
         -------
         function
-            A decorator which registers the function with the group using the
+            A decorator which registers the operation with the group using the
             specified directives.
         """
 
@@ -1176,13 +1177,6 @@ class FlowGroup:
         return directives
 
 
-def _document_directive(directive):
-    name = directive._name
-    name = name.replace("_", r"\_")
-    doc = directive.__doc__
-    return f"**{name}**\n\n{doc}"
-
-
 class _FlowProjectClass(type):
     """Metaclass for the FlowProject class."""
 
@@ -1478,7 +1472,7 @@ class _FlowProjectClass(type):
                 Parameters
                 ----------
                 directives : dict
-                    Directives to use for execution.
+                    Directives to use for resource requests and execution.
                 name : str
                     The operation name. Uses the name of the function if None
                     (Default value = None).

--- a/flow/project.py
+++ b/flow/project.py
@@ -17,6 +17,7 @@ import random
 import re
 import subprocess
 import sys
+import textwrap
 import threading
 import time
 import traceback
@@ -44,7 +45,7 @@ from .aggregates import (
     aggregator,
     get_aggregate_id,
 )
-from .environment import get_environment
+from .environment import ComputeEnvironment, get_environment
 from .errors import (
     ConfigKeyError,
     NoSchedulerError,
@@ -694,20 +695,29 @@ class FlowGroupEntry:
             func._flow_group_operation_directives = {self.name: directives}
 
     def with_directives(self, directives):
-        """Return a decorator that sets group specific directives to the operation.
+        """Decorate an operation to provide additional execution directives for this group.
+
+        Directives can be used to provide information about required resources
+        such as the number of processors required for execution of parallelized
+        operations. For a list of supported directives, see
+        :meth:`.FlowProject.operation.with_directives`. For more information,
+        see :ref:`signac-docs:cluster_submission_directives`.
+
+        The directives specified in this decorator are only applied when
+        executing the operation through the :class:`FlowGroup`.
+        To apply directives to an individual operation executed outside of the
+        group, see :meth:`.FlowProject.operation.with_directives`.
 
         Parameters
         ----------
         directives : dict
-            Directives to use for resource requests and running the operation
-            through the group.
+            Directives to use for execution.
 
         Returns
         -------
         function
-            A decorator which registers the function into the group with
+            A decorator which registers the function with the group using the
             specified directives.
-
         """
 
         def decorator(func):
@@ -1166,6 +1176,13 @@ class FlowGroup:
         return directives
 
 
+def _document_directive(directive):
+    name = directive._name
+    name = name.replace("_", r"\_")
+    doc = directive.__doc__
+    return f"**{name}**\n\n{doc}"
+
+
 class _FlowProjectClass(type):
     """Metaclass for the FlowProject class."""
 
@@ -1449,22 +1466,29 @@ class _FlowProjectClass(type):
                 return func
 
             def with_directives(self, directives, name=None):
-                """Return a decorator that also sets directives for the operation.
+                """Decorate a function to make it an operation with additional execution directives.
+
+                Directives can be used to provide information about required
+                resources such as the number of processors required for
+                execution of parallelized operations. For more information, see
+                :ref:`signac-docs:cluster_submission_directives`. To apply
+                directives to an operation that is part of a group, use
+                :meth:`.FlowGroupEntry.with_directives`.
 
                 Parameters
                 ----------
                 directives : dict
-                    Directives to use for resource requests and running the operation through the
-                    group.
+                    Directives to use for execution.
                 name : str
-                    The operation name. Uses the name of the function if None.
-                    (Default value = None)
+                    The operation name. Uses the name of the function if None
+                    (Default value = None).
 
                 Returns
                 -------
                 function
-                    A decorator which registers the function with the correct name and directives as
-                    an operation of the :class:`~.FlowProject` subclass.
+                    A decorator which registers the function with the provided
+                    name and directives as an operation of the
+                    :class:`~.FlowProject` subclass.
                 """
 
                 def add_operation_with_directives(function):
@@ -1472,6 +1496,18 @@ class _FlowProjectClass(type):
                     return self(function, name)
 
                 return add_operation_with_directives
+
+            _directives_to_document = (
+                ComputeEnvironment._get_default_directives()._directive_definitions.values()
+            )
+            with_directives.__doc__ += textwrap.indent(
+                "\n\n**Supported Directives:**\n\n"
+                + "\n\n".join(
+                    _document_directive(directive)
+                    for directive in _directives_to_document
+                ),
+                " " * 16,
+            )
 
         return OperationRegister()
 


### PR DESCRIPTION
## Description
This PR addresses a few issues in the documentation for directives.

First, the `@deprecated` decorator was being applied to `flow.directives`, which is a class. The `@deprecated` decorator can only be applied to _functions/methods_, so the docs refused to build on my machine. I'm unsure how (or if) this was working correctly on ReadTheDocs.

Second, we have deprecated `@flow.directives` in favor of `@FlowProject.operation.with_directives({...})`. However, the documentation was more extensive for `@flow.directives`. I copied these docs to the new location (this part of the docs is dynamically generated from the contents of `directives.py` and the default directives of `ComputeEnvironment`).

Finally, I added cross-links between `FlowGroupEntry.with_directives` and `FlowProject.operation.with_directives` so that their relationship is more clear.

- Fix `@flow.directives` docs.
- Add list of directives to `FlowProject.operation.with_directives`.
- Add cross-links between `FlowProject.operation.with_directives` and `FlowGroupEntry.with_directives`.

## Motivation and Context
📜 documentation is good 📜

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
