### PR TITLE
Clarify state point key in groupby docs.

### DIFF
--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -191,12 +191,12 @@ class aggregator:
         Examples
         --------
         The code block below provides an example of how to aggregate jobs
-        by a state point parameter ``"sp"``. If the state point does not
-        contain the key ``"sp"``, a default value of -1 is used.
+        by a state point parameter ``"key"``. If the state point does not
+        contain the key ``"key"``, a default value of -1 is used.
 
         .. code-block:: python
 
-            @aggregator.groupby(key="sp", default=-1)
+            @aggregator.groupby(key="key", default=-1)
             @FlowProject.operation
             def foo(*jobs):
                 print(len(jobs))


### PR DESCRIPTION
## Description
I changed the documentation for aggregation to use `"key"` as an example state point key, instead of `"sp"`, to avoid confusion with the recently introduced "unified query syntax" in the core signac package that also uses `sp` as an abbreviation/prefix.

## Motivation and Context
Increases clarity of docs. No changelog line is required here.

## Types of Changes
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [x] I have updated the API documentation as part of the package doc-strings.
- [x] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
