### PR TITLE
Use id property, require signac>=1.3.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
     <<: *test-template
     environment:
       DEPENDENCIES: "OLDEST"
-      SIGNAC_VERSION: "signac==1.0.0"
+      SIGNAC_VERSION: "signac==1.3.0"
     docker:
       - image: circleci/python:3.6
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,21 +81,26 @@ jobs:
           path: test-reports
           destination: test-reports
 
+  linux-python-39-signac-16:
+    <<: *test-template
+    environment:
+      DEPENDENCIES: "NEWEST"
+      SIGNAC_VERSION: "signac~=1.6.0"
   linux-python-39-signac-15:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "signac~=1.5.0"
-  linux-python-39-signac-14:
-    <<: *test-template
-    environment:
-      DEPENDENCIES: "NEWEST"
-      SIGNAC_VERSION: "signac~=1.4.0"
   linux-python-39-signac-latest:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
+  linux-python-39-signac-next:
+    <<: *test-template
+    environment:
+      DEPENDENCIES: "NEWEST"
+      SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git@next"
   linux-python-38:
     <<: *test-template
     docker:
@@ -163,10 +168,10 @@ workflows:
       - linux-python-38
       - linux-python-37
       - linux-python-36-oldest
-      - linux-python-39-signac-15:
+      - linux-python-39-signac-16:
           requires:
             - linux-python-39
-      - linux-python-39-signac-14:
+      - linux-python-39-signac-15:
           requires:
             - linux-python-39
       - check-metadata:
@@ -182,8 +187,8 @@ workflows:
             - linux-python-38
             - linux-python-37
             - linux-python-36-oldest
+            - linux-python-39-signac-16
             - linux-python-39-signac-15
-            - linux-python-39-signac-14
   nightly:
     triggers:
       - schedule:
@@ -194,6 +199,7 @@ workflows:
                 - master
     jobs:
       - linux-python-39-signac-latest
+      - linux-python-39-signac-next
   deploy:
     jobs:
       - deploy-pypi:

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Removed
 +++++++
 
 - Removed deprecated environment classes (#556).
+- Removed support for signac < 1.3.0 (#558).
 
 Version 0.15
 ============

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -455,7 +455,7 @@ class _AggregateStore(_BaseAggregateStore):
             for job in aggregate:
                 if job not in self._project:
                     raise LookupError(
-                        f"The signac job {job.get_id()} not found in {self._project}"
+                        f"The signac job {job.id} not found in {self._project}"
                     )
             try:
                 stored_aggregate = tuple(aggregate)
@@ -561,7 +561,7 @@ class _DefaultAggregateStore(_BaseAggregateStore):
 
     def keys(self):
         for job in self._project:
-            yield job.get_id()
+            yield job.id
 
     def values(self):
         for job in self._project:
@@ -569,7 +569,7 @@ class _DefaultAggregateStore(_BaseAggregateStore):
 
     def items(self):
         for job in self._project:
-            yield (job.get_id(), (job,))
+            yield (job.id, (job,))
 
 
 def get_aggregate_id(aggregate):
@@ -593,9 +593,9 @@ def get_aggregate_id(aggregate):
     """
     if len(aggregate) == 1:
         # Return job id as it's already unique
-        return aggregate[0].get_id()
+        return aggregate[0].id
 
-    id_string = ",".join(job.get_id() for job in aggregate)
+    id_string = ",".join(job.id for job in aggregate)
     hash_ = md5(id_string.encode("utf-8")).hexdigest()
     return f"agg-{hash_}"
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -90,7 +90,7 @@ The available template variables are:
 {template_vars}
 
 Filter functions can be used to format template variables in a specific way.
-For example: {{{{ project.get_id() | capitalize }}}}.
+For example: {{{{ project.id | capitalize }}}}.
 
 The available filters are:
 {filters}"""
@@ -2356,7 +2356,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         """
         result = {
-            "job_id": job.get_id(),
+            "job_id": job.id,
             "labels": [],
             "_labels_error": None,
         }
@@ -3035,7 +3035,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         return (
             operation.id,
             operation.name,
-            [job.get_id() for job in operation._jobs],
+            [job.id for job in operation._jobs],
             operation.cmd,
             operation.directives,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-signac>=1.0.0
+signac>=1.3.0
 jinja2>=2.10
 cloudpickle>=1.1.1
 deprecation>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,5 @@ omit =
 [bumpversion:file:.zenodo.json]
 
 [tool:pytest]
-filterwarnings = 
-	ignore:.*get_id is deprecated.*:DeprecationWarning
+filterwarnings =
 	ignore:.*The env argument is deprecated*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # The core package.
-    "signac>=1.0.0",
+    "signac>=1.3.0",
     # For the templated generation of (submission) scripts.
     "jinja2>=2.10",
     # To enable the parallelized execution of operations across processes.

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -357,5 +357,5 @@ class TestAggregateStore(AggregateProjectSetup):
         assert get_aggregate_id(jobs) in aggregator_instance
         assert get_aggregate_id(jobs) not in default_aggregator
         # Test for an aggregate of single job
-        assert not jobs[0].get_id() in aggregator_instance
-        assert jobs[0].get_id() in default_aggregator
+        assert not jobs[0].id in aggregator_instance
+        assert jobs[0].id in default_aggregator

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -900,7 +900,7 @@ class TestProject(TestProjectBase):
         project = self.mock_project()
         for job in project:
             status = project.get_job_status(job)
-            assert status["job_id"] == job.get_id()
+            assert status["job_id"] == job.id
             assert len(status["operations"]) == len(project.operations)
             for op in project._next_operations([(job,)]):
                 assert op.name in status["operations"]
@@ -1006,7 +1006,7 @@ execution_orders = (
     "cyclic",
     "by-job",
     "random",
-    lambda op: (op.name, op._jobs[0].get_id()),
+    lambda op: (op.name, op._jobs[0].id),
 )
 
 
@@ -1030,7 +1030,7 @@ class TestExecutionProject(TestProjectBase):
         # to the length of its set if and only if the job-operations are grouped
         # by job already.
         jobs_order_none = [
-            job.get_id() for job, _ in groupby(ops, key=lambda op: op._jobs[0])
+            job.id for job, _ in groupby(ops, key=lambda op: op._jobs[0])
         ]
         assert len(jobs_order_none) == len(set(jobs_order_none))
 
@@ -1466,7 +1466,7 @@ class TestProjectMainInterface(TestProjectBase):
         assert len(self.project)
         job_ids = set(self.call_subcmd("next op1").decode("utf-8").split())
         assert len(job_ids) > 0
-        even_jobs = [job.get_id() for job in self.project if job.sp.b % 2 == 0]
+        even_jobs = [job.id for job in self.project if job.sp.b % 2 == 0]
         assert job_ids == set(even_jobs)
         # Use only exact operation matches
         job_ids = set(self.call_subcmd("next op").decode("utf-8").split())
@@ -1492,7 +1492,7 @@ class TestProjectMainInterface(TestProjectBase):
         num_ops = len(project.operations)
         for line in lines:
             for job in project:
-                if job.get_id() in line:
+                if job.id in line:
                     op_lines = [line]
                     for i in range(num_ops - 1):
                         try:
@@ -1557,7 +1557,7 @@ class TestDirectivesProjectMainInterface(TestProjectBase):
         # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
         monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
-        job_id = next(iter(self.project)).get_id()
+        job_id = next(iter(self.project)).id
         output = self.call_subcmd(
             "submit -o op_walltime op_walltime_2 op_walltime_3 "
             f"-j {job_id} -b 3 --pretend --template slurm.sh",
@@ -1570,7 +1570,7 @@ class TestDirectivesProjectMainInterface(TestProjectBase):
         # FakeScheduler via the SIGNAC_FLOW_ENVIRONMENT environment variable.
         monkeypatch.setenv("SIGNAC_FLOW_ENVIRONMENT", "TestEnvironment")
         assert len(self.project)
-        job_id = next(iter(self.project)).get_id()
+        job_id = next(iter(self.project)).id
         output = self.call_subcmd(
             "submit -o op_walltime op_walltime_2 op_walltime_3 "
             f"-j {job_id} -b 3 --parallel --pretend --template slurm.sh",


### PR DESCRIPTION
## Description
This PR updates all usage of `job.get_id()` to the property `job.id`.

Changes in the API of signac for version 2.0 will remove the `job.get_id()` and `project.get_id()` methods in favor of the properties `job.id` and `project.id`. This PR for signac-flow updates its use of these ids, and should allow seamless compatibility for signac>=1.3.0, including major version 2.

Additionally, this PR adds nightly CI testing for the `next` branch of signac, which will become version 2.0.

## Motivation and Context
See comment: https://github.com/glotzerlab/signac/pull/578#issuecomment-886080077

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
