### PR TITLE
Remove --memory flag from GreatLakesEnvironment.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Removed
 - Removed deprecated environment classes (#556).
 - Removed support for signac < 1.3.0 (#558).
 - Removed support for decommissioned XSEDE Comet cluster (#537).
+- Removed ``--memory`` option from University of Michigan Great Lakes cluster submission. Use directives instead (#563).
 
 Version 0.15
 ============

--- a/flow/environments/umich.py
+++ b/flow/environments/umich.py
@@ -32,15 +32,6 @@ class GreatLakesEnvironment(DefaultSlurmEnvironment):
             default="standard",
             help="Specify the partition to submit to. (default=standard)",
         )
-        parser.add_argument(
-            "--memory",
-            default="4g",
-            help=(
-                'Specify how much memory to reserve per node, e.g. "4g" for '
-                '4 gigabytes or "512m" for 512 megabytes. Only relevant '
-                "for shared queue jobs. (default=4g)"
-            ),
-        )
 
 
 __all__ = ["GreatLakesEnvironment"]


### PR DESCRIPTION
## Description
This PR removes the `--memory` flag from the `GreatLakesEnvironment` command line API. Users should use `memory` directives instead.

## Motivation and Context
This was removed in #466 from all other clusters and left in one environment class by mistake.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [x] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
