### PR TITLE
Fix status check when no operations are eligible

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,14 @@ The numbers in brackets denote the related GitHub issue and/or pull request.
 Version 0.18
 ============
 
+[0.18.1] -- 2022-xx-xx
+----------------------
+
+Fixed
++++++
+
+- Fixed bug in project status output when no operations are eligible (#607, #609).
+
 [0.18.0] -- 2022-02-03
 ----------------------
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -3118,7 +3118,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 context["operation_status_symbols"] = OPERATION_STATUS_SYMBOLS
 
         def _add_placeholder_operation(job):
-            job["groups"][""] = {
+            job["groups"][None] = {
                 "completed": False,
                 "eligible": False,
                 "scheduler_status": JobStatus.placeholder,
@@ -3133,8 +3133,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         op_submission_status_counter = defaultdict(Counter)
         for job in context["jobs"]:
             for group_name, group_status in job["groups"].items():
-                display_name = group_status["display_name"]
-                if group_name != "":
+                # Exclude placeholder operations, which have no display name
+                if group_name is not None:
+                    display_name = group_status["display_name"]
                     if group_status["eligible"]:
                         op_counter[display_name] += 1
                     op_submission_status_counter[display_name][

--- a/flow/project.py
+++ b/flow/project.py
@@ -3118,7 +3118,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 context["operation_status_symbols"] = OPERATION_STATUS_SYMBOLS
 
         def _add_placeholder_operation(job):
-            job["groups"][None] = {
+            job["groups"][""] = {
                 "completed": False,
                 "eligible": False,
                 "scheduler_status": JobStatus.placeholder,
@@ -3134,7 +3134,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         for job in context["jobs"]:
             for group_name, group_status in job["groups"].items():
                 # Exclude placeholder operations, which have no display name
-                if group_name is not None:
+                if group_name != "":
                     display_name = group_status["display_name"]
                     if group_status["eligible"]:
                         op_counter[display_name] += 1

--- a/flow/project.py
+++ b/flow/project.py
@@ -3133,7 +3133,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         op_submission_status_counter = defaultdict(Counter)
         for job in context["jobs"]:
             for group_name, group_status in job["groups"].items():
-                # Exclude placeholder operations, which have no display name
+                # Exclude placeholder operations, which have no display name.
                 if group_name != "":
                     display_name = group_status["display_name"]
                     if group_status["eligible"]:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -250,6 +250,30 @@ class TestProjectStatusPerformance(TestProjectBase):
         assert time < 10
 
 
+class TestProjectStatusNoEligibleOperations(TestProjectBase):
+    class Project(FlowProject):
+        pass
+
+    @Project.operation
+    @Project.post(lambda job: True)
+    def foo(job):
+        pass
+
+    project_class = Project
+
+    def mock_project(self):
+        project = self.project_class.get_project(root=self._tmp_dir.name)
+        project.open_job(dict(i=0)).init()
+        return project
+
+    def test_status_no_eligible_operations(self):
+        """Test printing the project status when no operations are eligible."""
+        project = self.mock_project()
+        with redirect_stdout(StringIO()):
+            with redirect_stderr(StringIO()):
+                project.print_status()
+
+
 class TestProjectClass(TestProjectBase):
     def test_operation_definition(self):
         class A(FlowProject):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -263,7 +263,7 @@ class TestProjectStatusNoEligibleOperations(TestProjectBase):
 
     def mock_project(self):
         project = self.project_class.get_project(root=self._tmp_dir.name)
-        project.open_job({i: 0}).init()
+        project.open_job({"i": 0}).init()
         return project
 
     def test_status_no_eligible_operations(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -263,7 +263,7 @@ class TestProjectStatusNoEligibleOperations(TestProjectBase):
 
     def mock_project(self):
         project = self.project_class.get_project(root=self._tmp_dir.name)
-        project.open_job(dict(i=0)).init()
+        project.open_job({i: 0}).init()
         return project
 
     def test_status_no_eligible_operations(self):


### PR DESCRIPTION
## Description
This PR fixes a bug #607 introduced by #593. The key `"display_name"` does not exist for "placeholder operations," which are created to print an empty status line for jobs with no eligible operations.

**Once this PR and #608 are merged, we should create a patch release v0.18.1.**

## Motivation and Context
Resolves #607.

## Types of Changes
- [x] Bug fix

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
