### PR TITLE
Fix: tqdm.auto requires ipywidgets for notebook support.

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -1,5 +1,5 @@
 cloudpickle==1.1.1
 deprecation==2.0.0
 jinja2==2.10
-tqdm==4.48.1
+tqdm==4.60.0
 jsonschema==3.0.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,17 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.19
+============
+
+[0.19.0] -- 2022-xx-xx
+----------------------
+
+Fixed
++++++
+
+- Progress bars shown in notebooks fall back to text-based output if ipywidgets is not available (#602, #614).
+
 Version 0.18
 ============
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,11 @@ Version 0.19
 [0.19.0] -- 2022-xx-xx
 ----------------------
 
+Changed
++++++++
+
+- Drop support for `tqdm <https://github.com/tqdm/tqdm>`__ versions older than `4.60.0` (#614).
+
 Fixed
 +++++
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -36,7 +36,16 @@ import jsonschema
 import signac
 from jinja2 import TemplateNotFound as Jinja2TemplateNotFound
 from signac.contrib.filterparse import parse_filter_arg
-from tqdm.auto import tqdm
+
+try:
+    # If ipywidgets is installed, use "auto" tqdm to improve notebook support.
+    # Otherwise, use only text-based progress bars. This workaround can be
+    # removed after https://github.com/tqdm/tqdm/pull/1218.
+    import ipywidgets  # noqa: F401
+except ImportError:
+    from tqdm import tqdm
+else:
+    from tqdm.auto import tqdm
 
 from .aggregates import (
     _AggregatesCursor,

--- a/flow/project.py
+++ b/flow/project.py
@@ -37,16 +37,6 @@ import signac
 from jinja2 import TemplateNotFound as Jinja2TemplateNotFound
 from signac.contrib.filterparse import parse_filter_arg
 
-try:
-    # If ipywidgets is installed, use "auto" tqdm to improve notebook support.
-    # Otherwise, use only text-based progress bars. This workaround can be
-    # removed after https://github.com/tqdm/tqdm/pull/1218.
-    import ipywidgets  # noqa: F401
-except ImportError:
-    from tqdm import tqdm
-else:
-    from tqdm.auto import tqdm
-
 from .aggregates import (
     _AggregatesCursor,
     _AggregateStore,
@@ -82,6 +72,7 @@ from .util.misc import (
     add_cwd_to_environment_pythonpath,
     roundrobin,
     switch_to_directory,
+    tqdm,
 )
 from .util.translate import abbreviate, shorten
 

--- a/flow/render_status.py
+++ b/flow/render_status.py
@@ -2,18 +2,9 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 """Status rendering logic."""
-try:
-    # If ipywidgets is installed, use "auto" tqdm to improve notebook support.
-    # Otherwise, use only text-based progress bars. This workaround can be
-    # removed after https://github.com/tqdm/tqdm/pull/1218.
-    import ipywidgets  # noqa: F401
-except ImportError:
-    from tqdm import tqdm
-else:
-    from tqdm.auto import tqdm
-
 from .scheduling.base import JobStatus
 from .util import mistune
+from .util.misc import tqdm
 
 
 def _render_status(

--- a/flow/render_status.py
+++ b/flow/render_status.py
@@ -2,7 +2,15 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 """Status rendering logic."""
-from tqdm.auto import tqdm
+try:
+    # If ipywidgets is installed, use "auto" tqdm to improve notebook support.
+    # Otherwise, use only text-based progress bars. This workaround can be
+    # removed after https://github.com/tqdm/tqdm/pull/1218.
+    import ipywidgets  # noqa: F401
+except ImportError:
+    from tqdm import tqdm
+else:
+    from tqdm.auto import tqdm
 
 from .scheduling.base import JobStatus
 from .util import mistune

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -14,6 +14,16 @@ import cloudpickle
 from tqdm.contrib import tmap
 from tqdm.contrib.concurrent import process_map, thread_map
 
+try:
+    # If ipywidgets is installed, use "auto" tqdm to improve notebook support.
+    # Otherwise, use only text-based progress bars. This workaround can be
+    # removed after https://github.com/tqdm/tqdm/pull/1218.
+    import ipywidgets  # noqa: F401
+except ImportError:
+    from tqdm import tqdm
+else:
+    from tqdm.auto import tqdm
+
 
 def _positive_int(value):
     """Parse a command line argument as a positive integer.
@@ -348,7 +358,10 @@ def _get_parallel_executor(parallelization="none"):
 
     """
     if parallelization == "thread":
-        parallel_executor = thread_map
+
+        def parallel_executor(func, iterable, **kwargs):
+            return thread_map(func, iterable, tqdm_class=tqdm, **kwargs)
+
     elif parallelization == "process":
 
         def parallel_executor(func, iterable, **kwargs):
@@ -365,6 +378,7 @@ def _get_parallel_executor(parallelization="none"):
                 # regardless of whether it is a local function.
                 partial(_run_cloudpickled_func, cloudpickle.dumps(func)),
                 map(cloudpickle.dumps, iterable),
+                tqdm_class=tqdm,
                 **kwargs,
             )
 
@@ -374,6 +388,6 @@ def _get_parallel_executor(parallelization="none"):
             if "chunksize" in kwargs:
                 # Chunk size only applies to thread/process parallel executors
                 del kwargs["chunksize"]
-            return list(tmap(func, iterable, **kwargs))
+            return list(tmap(func, iterable, tqdm_class=tqdm, **kwargs))
 
     return parallel_executor

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ signac>=1.3.0
 jinja2>=2.10
 cloudpickle>=1.1.1
 deprecation>=2.0.0
-tqdm>=4.48.1
+tqdm>=4.60.0
 jsonschema>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     # Deprecation management
     "deprecation>=2.0.0",
     # Progress bars
-    "tqdm>=4.48.1",
+    "tqdm>=4.60.0",
     # For schema validation
     "jsonschema>=3.0.0",
 ]


### PR DESCRIPTION
## Description
This is a workaround for half of the issue reported in #602:

> The notebook issue is partially caused by #371. tqdm has an automatic mode that detects if it is in a notebook, and shows an HTML progress bar instead of a console one (the console format doesn't render very well in the notebook, I have sometimes seen the `\r` fail to clear the current line and instead output lots of lines with progress bars). This issue has been reported to tqdm as https://github.com/tqdm/tqdm/issues/1082 and there is a PR https://github.com/tqdm/tqdm/pull/1218 to fix it by falling back to the console progress bar.

This PR does not change the default behavior of showing/not showing progress bars. See #602 for more details on that issue.

This workaround requires https://github.com/tqdm/tqdm/pull/1148, so the minimum tqdm version has been bumped to 4.60.0.

## Motivation and Context
Workaround for https://github.com/tqdm/tqdm/pull/1218

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt).
