### PR TITLE
Disable nightly tests on next branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ workflows:
                 - master
     jobs:
       - linux-python-310-signac-latest
-      - linux-python-310-signac-next
+#     - linux-python-310-signac-next
       - test-install-pip-python-36
       - test-install-pip-python-37
       - test-install-pip-python-38


### PR DESCRIPTION
This PR disables nightly tests (which I think run weekly, not nightly) on the signac `next` branch. There are API breaking changes that were observed in #613. We will add compatibility for signac's `next` (2.0) branch in signac-flow closer to the release of signac 2.0. Resolves #613 for now.