### PR TITLE
Require Python 3.8+.

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -2,7 +2,7 @@ click==8.0.4
 cloudpickle==1.1.1
 coverage==6.2
 deprecation==2.0.0
-jinja2==2.10
+jinja2==3.0.0
 jsonschema==3.0.0
 pytest-cov==3.0.0
 pytest==7.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,21 +61,25 @@ jobs:
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "signac~=1.6.0"
+      PYTHON: python
   linux-python-310-signac-15:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "signac~=1.5.0"
+      PYTHON: python
   linux-python-310-signac-latest:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
+      PYTHON: python
   linux-python-310-signac-next:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git@next"
+      PYTHON: python
   linux-python-39:
     <<: *test-template
     docker:
@@ -86,29 +90,33 @@ jobs:
       - image: cimg/python:3.8
   linux-python-38-oldest:
     <<: *test-template
+    docker:
+      - image: cimg/python:3.8
     environment:
       DEPENDENCIES: "OLDEST"
       SIGNAC_VERSION: "signac==1.3.0"
-    docker:
-      - image: cimg/python:3.8
+      PYTHON: python
 
   test-install-pip-python-310: &test-install-pip
     docker:
       - image: cimg/python:3.10
+
+    environment:
+      PYTHON: python
 
     steps:
 
       - run:
           name: install-with-pip
           command: |
-            pip install --progress-bar off signac signac-flow
+            ${PYTHON} -m pip install --progress-bar off signac signac-flow
 
       - run: &smoke-test
           name: smoke-test
           command: |
-            signac --version
+            ${PYTHON} -m signac --version
             ${PYTHON} -c 'import signac'
-            flow --version
+            ${PYTHON} -m flow --version
             ${PYTHON} -c 'import flow'
 
   test-install-pip-python-39:
@@ -126,6 +134,7 @@ jobs:
       # The default job does not specify the version, just like the
       # instructions.
       PYTHON_DEP: ""
+      PYTHON: python
     docker:
       - image: conda/miniconda3:latest
 
@@ -143,16 +152,19 @@ jobs:
     <<: *test-install-conda
     environment:
       PYTHON_DEP: "python=3.10"
+      PYTHON: python
 
   test-install-conda-python-39:
     <<: *test-install-conda
     environment:
       PYTHON_DEP: "python=3.9"
+      PYTHON: python
 
   test-install-conda-python-38:
     <<: *test-install-conda
     environment:
       PYTHON_DEP: "python=3.8"
+      PYTHON: python
 
   check-metadata:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,13 @@ references:
 
 jobs:
   linux-python-310: &test-template
+    docker:
+      - image: cimg/python:3.10
+
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "signac"
-    docker:
-      - image: cimg/python:3.10
+      PYTHON: python
 
     working_directory: ~/repo
 
@@ -28,27 +30,27 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            python -m pip install --progress-bar off -U virtualenv --user
+            ${PYTHON} -m pip install --progress-bar off -U virtualenv --user
             mkdir -p ./venv
-            python -m virtualenv ./venv --clear
+            ${PYTHON} -m virtualenv ./venv --clear
             . venv/bin/activate
-            python -m pip install --progress-bar off -U pip>=20.3
-            python -m pip install --progress-bar off -U codecov
-            python -m pip install --progress-bar off ${SIGNAC_VERSION}
+            ${PYTHON} -m pip install --progress-bar off -U pip>=20.3
+            ${PYTHON} -m pip install --progress-bar off -U codecov
+            ${PYTHON} -m pip install --progress-bar off ${SIGNAC_VERSION}
             # DEPENDENCIES can be "OLDEST" or "NEWEST"
             if [ "${DEPENDENCIES}" == "OLDEST" ]; then
-              python -m pip install --progress-bar off -r .circleci/ci-oldest-reqs.txt
+              ${PYTHON} -m pip install --progress-bar off -r .circleci/ci-oldest-reqs.txt
             else
-              python -m pip install --progress-bar off -r requirements.txt
-              python -m pip install --progress-bar off -r requirements/requirements-test.txt
+              ${PYTHON} -m pip install --progress-bar off -r requirements.txt
+              ${PYTHON} -m pip install --progress-bar off -r requirements/requirements-test.txt
             fi
 
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            python -m pytest --cov=flow --cov-config=setup.cfg --cov-report=xml tests/ -v
-            codecov
+            ${PYTHON} -m pytest --cov=flow --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m codecov
 
       - store_artifacts:
           path: test-reports
@@ -82,21 +84,17 @@ jobs:
     <<: *test-template
     docker:
       - image: cimg/python:3.8
-  linux-python-37:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.7
-  linux-python-36-oldest:
+  linux-python-38-oldest:
     <<: *test-template
     environment:
       DEPENDENCIES: "OLDEST"
       SIGNAC_VERSION: "signac==1.3.0"
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.8
 
-  test-install-pip-python-36: &test-install-pip
+  test-install-pip-python-310: &test-install-pip
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.10
 
     steps:
 
@@ -109,29 +107,19 @@ jobs:
           name: smoke-test
           command: |
             signac --version
-            python -c 'import signac'
+            ${PYTHON} -c 'import signac'
             flow --version
-            python -c 'import flow'
-
-  test-install-pip-python-37:
-    <<: *test-install-pip
-    docker:
-      - image: cimg/python:3.7
-
-  test-install-pip-python-38:
-    <<: *test-install-pip
-    docker:
-      - image: cimg/python:3.8
+            ${PYTHON} -c 'import flow'
 
   test-install-pip-python-39:
     <<: *test-install-pip
     docker:
       - image: cimg/python:3.9
 
-  test-install-pip-python-310:
+  test-install-pip-python-38:
     <<: *test-install-pip
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.8
 
   test-install-conda: &test-install-conda
     environment:
@@ -151,30 +139,20 @@ jobs:
       - run:
           <<: *smoke-test
 
-  test-install-conda-python-36:
+  test-install-conda-python-310:
     <<: *test-install-conda
     environment:
-      PYTHON_DEP: "python=3.6"
-
-  test-install-conda-python-37:
-    <<: *test-install-conda
-    environment:
-      PYTHON_DEP: "python=3.7"
-
-  test-install-conda-python-38:
-    <<: *test-install-conda
-    environment:
-      PYTHON_DEP: "python=3.8"
+      PYTHON_DEP: "python=3.10"
 
   test-install-conda-python-39:
     <<: *test-install-conda
     environment:
       PYTHON_DEP: "python=3.9"
 
-  test-install-conda-python-310:
+  test-install-conda-python-38:
     <<: *test-install-conda
     environment:
-      PYTHON_DEP: "python=3.10"
+      PYTHON_DEP: "python=3.8"
 
   check-metadata:
     docker:
@@ -225,8 +203,7 @@ workflows:
       - linux-python-310
       - linux-python-39
       - linux-python-38
-      - linux-python-37
-      - linux-python-36-oldest
+      - linux-python-38-oldest
       - linux-python-310-signac-16:
           requires:
             - linux-python-310
@@ -245,8 +222,7 @@ workflows:
             - linux-python-310
             - linux-python-39
             - linux-python-38
-            - linux-python-37
-            - linux-python-36-oldest
+            - linux-python-38-oldest
             - linux-python-310-signac-16
             - linux-python-310-signac-15
   nightly:
@@ -260,17 +236,13 @@ workflows:
     jobs:
       - linux-python-310-signac-latest
 #     - linux-python-310-signac-next
-      - test-install-pip-python-36
-      - test-install-pip-python-37
-      - test-install-pip-python-38
-      - test-install-pip-python-39
       - test-install-pip-python-310
+      - test-install-pip-python-39
+      - test-install-pip-python-38
       - test-install-conda
-      - test-install-conda-python-36
-      - test-install-conda-python-37
-      - test-install-conda-python-38
-      - test-install-conda-python-39
       - test-install-conda-python-310
+      - test-install-conda-python-39
+      - test-install-conda-python-38
   deploy:
     jobs:
       - deploy-pypi:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         exclude: 'setup.cfg'
       - id: debug-statements
   - repo: https://github.com/asottile/pyupgrade
-    rev: 'v2.31.0'
+    rev: 'v2.31.1'
     hooks:
       - id: pyupgrade
         args:
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: '21.12b0'
+    rev: '22.1.0'
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py38-plus
   - repo: https://github.com/PyCQA/isort
     rev: '5.10.1'
     hooks:

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Removed
 
 - Internal utility functions have been removed from the public API (#615).
 - Dropped support for Python 3.6 and Python 3.7 (#715) following the recommended support schedules of `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
+- Drop support for `Jinja2 <https://palletsprojects.com/p/jinja/>`__ versions older than `3.0.0` (#436).
 
 Version 0.18
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,7 +27,7 @@ Removed
 
 - Internal utility functions have been removed from the public API (#615).
 - Dropped support for Python 3.6 and Python 3.7 (#715) following the recommended support schedules of `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
-- Drop support for `Jinja2 <https://palletsprojects.com/p/jinja/>`__ versions older than `3.0.0` (#436).
+- Drop support for `Jinja2 <https://palletsprojects.com/p/jinja/>`__ versions below `3.0.0` (#436).
 
 Version 0.18
 ============

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,8 +5,8 @@ Installation
 ============
 
 The recommended installation method for **signac-flow** is via conda_ or pip_.
-The software is tested for Python versions 3.6+ and signac_ versions 1.0+.
-Supported Python and NumPy versions are determined according to the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
+The software is tested for Python versions 3.8+ and signac_ versions 1.3+.
+The signac framework uses the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ as a guideline for when to drop support for Python and NumPy versions, and does not guarantee support beyond the versions recommended in that proposal.
 
 .. _conda: https://conda.io/
 .. _conda-forge: https://conda-forge.org/

--- a/flow/project.py
+++ b/flow/project.py
@@ -1782,10 +1782,6 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             "get_account_name"
         ] = template_filters.get_account_name
         template_environment.filters["print_warning"] = template_filters.print_warning
-        if "max" not in template_environment.filters:  # for jinja2 < 2.10
-            template_environment.filters["max"] = max
-        if "min" not in template_environment.filters:  # for jinja2 < 2.10
-            template_environment.filters["min"] = min
         template_environment.filters["quote_argument"] = shlex.quote
 
         return template_environment

--- a/flow/project.py
+++ b/flow/project.py
@@ -130,7 +130,7 @@ class IgnoreConditions(IntFlag):
         # Compute the largest number of bits used to represent one of the flags
         # so that we can XOR the appropriate number.
         max_bits = len(bin(max(elem.value for elem in type(self)))) - 2
-        return self.__class__((2 ** max_bits - 1) ^ self._value_)
+        return self.__class__((2**max_bits - 1) ^ self._value_)
 
     NONE = 0
     """Check all conditions."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 signac>=1.3.0
-jinja2>=2.10
+jinja2>=3.0.0
 cloudpickle>=1.1.1
 deprecation>=2.0.0
 tqdm>=4.60.0

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Physics",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -68,5 +66,5 @@ setup(
     install_requires=requirements,
     # Supported versions are determined according to NEP 29.
     # https://numpy.org/neps/nep-0029-deprecation_policy.html
-    python_requires=">=3.6, <4",
+    python_requires=">=3.8, <4",
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     # The core package.
     "signac>=1.3.0",
     # For the templated generation of (submission) scripts.
-    "jinja2>=2.10",
+    "jinja2>=3.0.0",
     # To enable the parallelized execution of operations across processes.
     "cloudpickle>=1.1.1",
     # Deprecation management


### PR DESCRIPTION
## Description
NEP 29 has dropped support for Python < 3.8. This PR updates signac-flow to require Python 3.8+.

See also https://github.com/glotzerlab/signac/pull/715.

I also updated our Jinja requirement to 3.0.0. Older versions of Jinja are incompatible with the latest version of markupsafe, one of Jinja’s dependencies. Requiring Jinja 3.0.0+ fixes this, and allows us to drop some compatibility code.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.