### PR TITLE
Change hook names in auto doc table of contents

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,8 +24,8 @@ The FlowProject
     FlowProject.operation
     FlowProject.operation.with_directives
     FlowProject.operation_hooks
-    FlowProject.operation_hooks.on_fail
-    FlowProject.operation_hooks.on_finish
+    FlowProject.operation_hooks.on_exception
+    FlowProject.operation_hooks.on_exit
     FlowProject.operation_hooks.on_start
     FlowProject.operation_hooks.on_success
     FlowProject.operations
@@ -62,9 +62,9 @@ The FlowProject
 
 .. automethod:: flow.FlowProject.operation_hooks(hook_func, trigger)
 
-.. automethod:: flow.FlowProject.operation_hooks.on_fail
+.. automethod:: flow.FlowProject.operation_hooks.on_exception
 
-.. automethod:: flow.FlowProject.operation_hooks.on_finish
+.. automethod:: flow.FlowProject.operation_hooks.on_exit
 
 .. automethod:: flow.FlowProject.operation_hooks.on_start
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Docs for `on_exception` and `on_exit` [weren't showing up](https://docs.signac.io/projects/flow/en/latest/api.html#the-flowproject) because the wrong names were in the toc.

Tested by building locally

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
