### PR TITLE
Allow for options to be passed to exec through groups

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,11 +15,14 @@ Added
 +++++
 
 - Added support to run aggregate operations in parallel (#642, #644).
+- Added an argument, ``run_options``, to ``FlowProject.make_group`` which allows passing options to ``exec`` for operations running in a different process (#650).
 
 Changed
 +++++++
+
 - Deprecated configuaration key 'flow.environment_modules' (#651).
 - Deprecated configuration key 'flow.import_packaged_environments' (#651).
+- Changed argument ``options`` to ``submit_options`` in ``FlowProject.make_group`` (#650).
 
 Removed
 +++++++

--- a/flow/project.py
+++ b/flow/project.py
@@ -651,18 +651,24 @@ class FlowGroupEntry:
         The name of the :class:`FlowGroup` to be created.
     project : flow.FlowProject
         The project the group is associated with.
-    options : str
+    submit_options : str
         The :meth:`FlowProject.run` options to pass when submitting the group.
         These will be included in all submissions. Submissions use run
         commands to execute.
+    run_options : str
+        The options to pass to ``entrypoint exec`` when running the group. These will only be used
+        when the operation is forked instead of running in the same Python interpretor.
     group_aggregator : :class:`~.aggregator`
         aggregator object associated with the :class:`FlowGroup` (Default value = None).
     """
 
-    def __init__(self, name, project, options="", group_aggregator=None):
+    def __init__(
+        self, name, project, submit_options="", run_options="", group_aggregator=None
+    ):
         self.name = name
         self._project = project
-        self.options = options
+        self.submit_options = submit_options
+        self.run_options = run_options
         # We register aggregators associated with operation functions in
         # `_register_groups` and we do not set the aggregator explicitly.
         # We delay setting the aggregator because we do not restrict the
@@ -785,17 +791,26 @@ class FlowGroup:
         the directives of the singleton group containing that operation are
         used. To prevent this, set the directives to an empty dictionary for
         that operation.
-    options : str
-        A string of options to append to the output of the object's call method.
-        This allows options like ``--num_passes`` to be given to a group.
-
+    run_options : str
+        The options to pass to ``entrypoint exec`` when running the group. These will only be used
+        when the operation is forked instead of running in the same Python interpretor.
+    group_aggregator : :class:`~.aggregator`
+        aggregator object associated with the :class:`FlowGroup` (Default value = None).
     """
 
     MAX_LEN_ID = 100
 
-    def __init__(self, name, operations=None, operation_directives=None, options=""):
+    def __init__(
+        self,
+        name,
+        operations=None,
+        operation_directives=None,
+        submit_options="",
+        run_options="",
+    ):
         self.name = name
-        self.options = options
+        self.submit_options = submit_options
+        self.run_options = run_options
         # Requires Python >=3.6: dict must be ordered to ensure consistent
         # pretend submission output for templates.
         self.operations = {} if operations is None else dict(operations)
@@ -840,20 +855,21 @@ class FlowGroup:
             all_directives.update(defaults.get(name, {}))
         return all_directives
 
-    def _submit_cmd(self, entrypoint, ignore_conditions, jobs=None):
+    def _submit_cmd(self, entrypoint, ignore_conditions, jobs):
         entrypoint = self._determine_entrypoint(entrypoint, {}, jobs)
         cmd = f"{entrypoint} run -o {self.name}"
         cmd = cmd if jobs is None else cmd + f" -j {get_aggregate_id(jobs)}"
-        cmd = cmd if self.options is None else cmd + " " + self.options
+        options = self.submit_options
         if ignore_conditions != IgnoreConditions.NONE:
-            return cmd.strip() + " --ignore-conditions=" + str(ignore_conditions)
-        return cmd.strip()
+            options += " --ignore-conditions=" + str(ignore_conditions)
+        return " ".join((cmd, options)).strip()
 
     def _run_cmd(self, entrypoint, operation_name, operation, directives, jobs):
         if isinstance(operation, FlowCmdOperation):
             return operation(*jobs).lstrip()
         entrypoint = self._determine_entrypoint(entrypoint, directives, jobs)
-        return f"{entrypoint} exec {operation_name} {get_aggregate_id(jobs)}".lstrip()
+        cmd = f"{entrypoint} exec {operation_name} {get_aggregate_id(jobs)} {self.run_options}"
+        return cmd.strip()
 
     def __iter__(self):
         yield from self.operations.values()
@@ -861,12 +877,14 @@ class FlowGroup:
     def __repr__(self):
         return (
             "{type}(name='{name}', operations='{operations}', "
-            "operation_directives={directives}, options='{options}')".format(
+            "operation_directives={directives}, submit_options='{submit_options}', "
+            "run_options='{run_options}')".format(
                 type=type(self).__name__,
                 name=self.name,
                 operations=" ".join(list(self.operations)),
                 directives=self.operation_directives,
-                options=self.options,
+                submit_options=self.submit_options,
+                run_options=self.run_options,
             )
         )
 
@@ -1475,7 +1493,7 @@ class _FlowProjectClass(type):
                 # placement in terms of `@FlowGroupEntry`, `@aggregator`, or
                 # `@operation`.
                 self._parent_class._GROUPS.append(
-                    FlowGroupEntry(name=name, project=self._parent_class, options="")
+                    FlowGroupEntry(name=name, project=self._parent_class)
                 )
                 if not hasattr(func, "_flow_groups"):
                     func._flow_groups = {}
@@ -4459,7 +4477,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
                 self._operations[name] = FlowOperation(op_func=func, **params)
 
     @classmethod
-    def make_group(cls, name, options="", group_aggregator=None):
+    def make_group(cls, name, submit_options="", run_options="", group_aggregator=None):
         r"""Make a :class:`~.FlowGroup` named ``name`` and return a decorator to make groups.
 
         A :class:`~.FlowGroup` is used to group operations together for
@@ -4482,9 +4500,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         ----------
         name : str
             The name of the :class:`~.FlowGroup`.
-        options : str
-            A string to append to submissions. Can be any valid
-            :meth:`FlowOperation.run` option. (Default value = "")
+        submit_options : str
+            The :meth:`FlowProject.run` options to pass when submitting the group. These will be
+            included in all submissions. Submissions use run commands to execute.
+        run_options : str
+            The options to pass to ``entrypoint exec`` when running the group. These will only be
+            used when the operation is forked instead of running in the same Python interpretor.
         group_aggregator : :class:`~.aggregator`
             An instance of :class:`~flow.aggregator` to associate with the :class:`FlowGroup`.
             If None, no aggregation takes place (Default value = None).
@@ -4507,7 +4528,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             )
         cls._GROUP_NAMES.add(name)
         group_entry = FlowGroupEntry(
-            name=name, project=cls, options=options, group_aggregator=group_aggregator
+            name=name,
+            project=cls,
+            submit_options=submit_options,
+            run_options=run_options,
+            group_aggregator=group_aggregator,
         )
         cls._GROUPS.append(group_entry)
         return group_entry
@@ -4530,7 +4555,11 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # equivalent aggregators only generate once.
         created_aggregate_stores = {}
         for entry in group_entries:
-            group = FlowGroup(entry.name, options=entry.options)
+            group = FlowGroup(
+                entry.name,
+                submit_options=entry.submit_options,
+                run_options=entry.run_options,
+            )
             self._groups[entry.name] = group
             # Handle unset aggregators
             if entry.group_aggregator is None:

--- a/flow/project.py
+++ b/flow/project.py
@@ -659,7 +659,6 @@ class FlowGroupEntry:
         The options to pass to ``entrypoint exec`` when running the group. Specifying this will
         cause the operation to be forked even if it otherwise would run in the current Python
         interpreter.
-        when the operation is forked instead of running in the same Python interpretor.
     group_aggregator : :class:`~.aggregator`
         aggregator object associated with the :class:`FlowGroup` (Default value = None).
     """

--- a/flow/project.py
+++ b/flow/project.py
@@ -879,16 +879,10 @@ class FlowGroup:
 
     def __repr__(self):
         return (
-            "{type}(name='{name}', operations='{operations}', "
-            "operation_directives={directives}, submit_options='{submit_options}', "
-            "run_options='{run_options}')".format(
-                type=type(self).__name__,
-                name=self.name,
-                operations=" ".join(list(self.operations)),
-                directives=self.operation_directives,
-                submit_options=self.submit_options,
-                run_options=self.run_options,
-            )
+            f"{type(self).__name__}(name={repr(self.name)}, operations='"
+            f"{' '.join(list(self.operations))}',"
+            f"operation_directives={self.operation_directives}, "
+            f"submit_options={repr(self.submit_options)}, run_options={repr(self.run_options)})"
         )
 
     def _eligible(self, aggregate, ignore_conditions=IgnoreConditions.NONE):

--- a/flow/project.py
+++ b/flow/project.py
@@ -656,7 +656,9 @@ class FlowGroupEntry:
         These will be included in all submissions. Submissions use run
         commands to execute.
     run_options : str
-        The options to pass to ``entrypoint exec`` when running the group. These will only be used
+        The options to pass to ``entrypoint exec`` when running the group. Specifying this will
+        cause the operation to be forked even if it otherwise would run in the current Python
+        interpreter.
         when the operation is forked instead of running in the same Python interpretor.
     group_aggregator : :class:`~.aggregator`
         aggregator object associated with the :class:`FlowGroup` (Default value = None).
@@ -795,8 +797,9 @@ class FlowGroup:
         The :meth:`FlowProject.run` options to pass when submitting the group. These will be
         included in all submissions. Submissions use run commands to execute.
     run_options : str
-        The options to pass to ``entrypoint exec`` when running the group. These will only be used
-        when the operation is forked instead of running in the same Python interpretor.
+        The options to pass to ``entrypoint exec`` when running the group. Specifying this will
+        cause the operation to be forked even if it otherwise would run in the current Python
+        interpreter.
     """
 
     MAX_LEN_ID = 100
@@ -1184,7 +1187,7 @@ class FlowGroup:
                 # to True since we must launch a separate process. Override
                 # the command directly.
                 prefix = jobs[0]._project._environment.get_prefix(job_op)
-                if prefix != "":
+                if prefix != "" or self.run_options != "":
                     job_op.directives["fork"] = True
                     job_op._cmd = f"{prefix} {job_op.cmd}"
                 yield job_op
@@ -4505,8 +4508,9 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             The :meth:`FlowProject.run` options to pass when submitting the group. These will be
             included in all submissions. Submissions use run commands to execute.
         run_options : str
-            The options to pass to ``entrypoint exec`` when running the group. These will only be
-            used when the operation is forked instead of running in the same Python interpretor.
+            The options to pass to ``entrypoint exec`` when running the group. Specifying this will
+            cause the operation to be forked even if it otherwise would run in the current Python
+            interpreter.
         group_aggregator : :class:`~.aggregator`
             An instance of :class:`~flow.aggregator` to associate with the :class:`FlowGroup`.
             If None, no aggregation takes place (Default value = None).

--- a/flow/project.py
+++ b/flow/project.py
@@ -791,11 +791,12 @@ class FlowGroup:
         the directives of the singleton group containing that operation are
         used. To prevent this, set the directives to an empty dictionary for
         that operation.
+    submit_options : str
+        The :meth:`FlowProject.run` options to pass when submitting the group. These will be
+        included in all submissions. Submissions use run commands to execute.
     run_options : str
         The options to pass to ``entrypoint exec`` when running the group. These will only be used
         when the operation is forked instead of running in the same Python interpretor.
-    group_aggregator : :class:`~.aggregator`
-        aggregator object associated with the :class:`FlowGroup` (Default value = None).
     """
 
     MAX_LEN_ID = 100

--- a/tests/define_test_project.py
+++ b/tests/define_test_project.py
@@ -9,7 +9,7 @@ class _TestProject(FlowProject):
 
 
 group1 = _TestProject.make_group(name="group1")
-group2 = _TestProject.make_group(name="group2", options="--num-passes=2")
+group2 = _TestProject.make_group(name="group2", submit_options="--num-passes=2")
 
 
 @_TestProject.label

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1968,8 +1968,51 @@ class TestGroupProject(TestProjectBase):
         assert all(op in rep_string for op in ["op1", "op2", "op3"])
         assert "'nranks': 4" in rep_string
         assert "'ngpu': 2" in rep_string
-        assert "options=''" in rep_string
+        assert "submit_options=''" in rep_string
+        assert "run_options=''" in rep_string
         assert "name='group'" in rep_string
+
+    def test_submit_options(self):
+        class A(flow.FlowProject):
+            pass
+
+        group = A.make_group("group", submit_options="--debug")
+
+        @group
+        @A.operation
+        def op1(job):
+            pass
+
+        project = self.mock_project(A)
+        group = project.groups["group"]
+        job = (next(iter(project)),)
+        submission_cmd = group._submit_cmd(
+            project._entrypoint, ignore_conditions=flow.IgnoreConditions, jobs=job
+        )
+        assert " --debug" in submission_cmd
+
+    def test_run_options(self):
+        class A(flow.FlowProject):
+            pass
+
+        group = A.make_group("group", run_options="--debug")
+
+        @group
+        @A.operation
+        def op1(job):
+            pass
+
+        project = self.mock_project(A)
+        group = project.groups["group"]
+        job = (next(iter(project)),)
+        run_cmd = group._run_cmd(
+            entrypoint=project._entrypoint,
+            operation_name="op1",
+            operation=project.operations["op1"],
+            directives={},
+            jobs=job,
+        )
+        assert " --debug" in run_cmd
 
 
 class TestGroupExecutionProject(TestProjectBase):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2005,14 +2005,15 @@ class TestGroupProject(TestProjectBase):
         project = self.mock_project(A)
         group = project.groups["group"]
         job = (next(iter(project)),)
-        run_cmd = group._run_cmd(
-            entrypoint=project._entrypoint,
-            operation_name="op1",
-            operation=project.operations["op1"],
-            directives={},
-            jobs=job,
+        run_ops = list(
+            group._create_run_job_operations(
+                entrypoint=project._entrypoint,
+                default_directives={},
+                jobs=job,
+            )
         )
-        assert " --debug" in run_cmd
+        assert all(" --debug" in op.cmd for op in run_ops)
+        assert all(op.directives["fork"] for op in run_ops)
 
 
 class TestGroupExecutionProject(TestProjectBase):


### PR DESCRIPTION


## Description
Enables execution of exec commands with arbitrary options appended through the `FlowGroup` attribute `run_options`. Also renames `options` to `submit_options`.

## Motivation and Context
To debug or pass flags to `project.py exec` is very difficult currently. This simplifies the process greatly which enhances our usefulness for containerized workflows.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
