### PR TITLE
Give FutureWarning on use of deprecated flow config keys

### DIFF
--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -8,6 +8,8 @@ configure and implement a workflow to operate on a signac_ data space.
 
 .. _signac: https://signac.io/
 """
+import warnings
+
 from . import environment, errors, hooks, scheduling, testing
 from .aggregates import aggregator, get_aggregate_id
 from .environment import get_environment
@@ -44,10 +46,23 @@ __all__ = [
 ]
 
 
-if _get_config_value(
+_import_packaged_environments = _get_config_value(
     "import_packaged_environments",
-    default=_FLOW_CONFIG_DEFAULTS["import_packaged_environments"],
-):
+    default=None,  # Use None to determine if this is being used or not.
+)
+
+if _import_packaged_environments is None:
+    _import_packaged_environments = _FLOW_CONFIG_DEFAULTS[
+        "import_packaged_environments"
+    ]
+else:
+    warnings.warn(
+        "Config key import_packaged_environments will be removed in signac-flow version 0.21. "
+        "Environments will always install once removed. Remove key from config to remove warning.",
+        FutureWarning,
+    )
+
+if _import_packaged_environments:
     from . import environments  # noqa: F401
 
     __all__.append("environments")

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -57,8 +57,8 @@ if _import_packaged_environments is None:
     ]
 else:
     warnings.warn(
-        "Config key import_packaged_environments will be removed in signac-flow version 0.21. "
-        "Environments will always install once removed. Remove key from config to remove warning.",
+        "The configuration key flow.import_packaged_environments will be removed in signac-flow version 0.21. "
+        "To remove this warning, remove the flow.import_packaged_environments key from your signac configuration. In the future, environments provided by signac-flow will always be imported."
         FutureWarning,
     )
 

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -57,8 +57,10 @@ if _import_packaged_environments is None:
     ]
 else:
     warnings.warn(
-        "The configuration key flow.import_packaged_environments will be removed in signac-flow version 0.21. "
-        "To remove this warning, remove the flow.import_packaged_environments key from your signac configuration. In the future, environments provided by signac-flow will always be imported."
+        "The configuration key flow.import_packaged_environments will be removed in signac-flow "
+        "version 0.21. To remove this warning, remove the flow.import_packaged_environments key "
+        "from your signac configuration. In the future, environments provided by signac-flow will "
+        "always be imported.",
         FutureWarning,
     )
 

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import socket
+import warnings
 from functools import lru_cache
 
 from signac.common import config
@@ -59,7 +60,16 @@ def setup(py_modules, **attrs):
     an environment's module, but also register it with the global signac
     configuration. Once registered, the environment is automatically
     imported when the :meth:`~flow.get_environment` function is called.
+
+    Warning
+    -------
+        This function is deprecated. Install user environments manually.
     """
+    warnings.warn(
+        "Config key environment_modules will be removed in signac-flow version 0.21. "
+        "Manual install environments instead.",
+        FutureWarning,
+    )
     import setuptools
     from setuptools.command.install import install
 
@@ -517,6 +527,12 @@ def _import_configured_environments():
                 logger.warning(error)
     except KeyError:
         pass
+    else:
+        warnings.warn(
+            "Config key environment_modules will be removed  in signac-flow version 0.21. "
+            "Manual import environments instead.",
+            FutureWarning,
+        )
 
 
 def registered_environments(import_configured=True):

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -60,14 +60,10 @@ def setup(py_modules, **attrs):
     an environment's module, but also register it with the global signac
     configuration. Once registered, the environment is automatically
     imported when the :meth:`~flow.get_environment` function is called.
-
-    Warning
-    -------
-        This function is deprecated. Install user environments manually.
     """
     warnings.warn(
-        "The configuration key flow.environment_modules will be removed in signac-flow version 0.21. "
-        "Users should manually import user-defined environments instead.",
+        "The configuration key flow.environment_modules will be removed in signac-flow version "
+        "0.21. Users should manually import user-defined environments instead.",
         FutureWarning,
     )
     import setuptools
@@ -529,8 +525,8 @@ def _import_configured_environments():
         pass
     else:
         warnings.warn(
-            "The configuration key flow.environment_modules will be removed in signac-flow version 0.21. "
-            "Users should manually import user-defined environments instead.",
+            "The configuration key flow.environment_modules will be removed in signac-flow version "
+            "0.21. Users should manually import user-defined environments instead.",
             FutureWarning,
         )
 

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -66,8 +66,8 @@ def setup(py_modules, **attrs):
         This function is deprecated. Install user environments manually.
     """
     warnings.warn(
-        "Config key environment_modules will be removed in signac-flow version 0.21. "
-        "Manual install environments instead.",
+        "The configuration key flow.environment_modules will be removed in signac-flow version 0.21. "
+        "Users should manually import user-defined environments instead.",
         FutureWarning,
     )
     import setuptools
@@ -529,8 +529,8 @@ def _import_configured_environments():
         pass
     else:
         warnings.warn(
-            "Config key environment_modules will be removed  in signac-flow version 0.21. "
-            "Manual import environments instead.",
+            "The configuration key flow.environment_modules will be removed in signac-flow version 0.21. "
+            "Users should manually import user-defined environments instead.",
             FutureWarning,
         )
 


### PR DESCRIPTION
## Description

- Warn on use of environment_modules
- Warn on use of import_packaged_environments

__Note__: Given our vendoring of `deprecation` in `signac`, I was not sure of how we wanted to handle this in `flow`. For now, I just manually used the warnings module which I would have to do anyways in all but one place. 

## Motivation and Context
We plan on removing the features as they are the only configuration values needed without a project, and lead to an increased overhead without much benefit.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
