### PR TITLE
Remove import packaged environments

### DIFF
--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -8,9 +8,7 @@ configure and implement a workflow to operate on a signac_ data space.
 
 .. _signac: https://signac.io/
 """
-import warnings
-
-from . import environment, errors, hooks, scheduling, testing
+from . import environment, environments, errors, hooks, scheduling, testing
 from .aggregates import aggregator, get_aggregate_id
 from .environment import get_environment
 from .operations import cmd, directives, with_job
@@ -18,13 +16,12 @@ from .project import FlowProject, IgnoreConditions, classlabel, label, staticlab
 from .template import init
 
 # Import packaged environments unless disabled in config:
-from .util.config import _FLOW_CONFIG_DEFAULTS
-from .util.config import get_config_value as _get_config_value
 from .util.misc import redirect_log
 from .version import __version__
 
 __all__ = [
     "environment",
+    "environments",
     "errors",
     "hooks",
     "scheduling",
@@ -44,25 +41,3 @@ __all__ = [
     "redirect_log",
     "__version__",
 ]
-
-
-_import_packaged_environments = _get_config_value(
-    "import_packaged_environments",
-    default=None,  # Use None to determine if this is being used or not.
-)
-
-if _import_packaged_environments is None:
-    _import_packaged_environments = _FLOW_CONFIG_DEFAULTS[
-        "import_packaged_environments"
-    ]
-else:
-    warnings.warn(
-        "Config key import_packaged_environments will be removed in signac-flow version 0.21. "
-        "Environments will always install once removed. Remove key from config to remove warning.",
-        FutureWarning,
-    )
-
-if _import_packaged_environments:
-    from . import environments  # noqa: F401
-
-    __all__.append("environments")

--- a/flow/__init__.py
+++ b/flow/__init__.py
@@ -8,6 +8,8 @@ configure and implement a workflow to operate on a signac_ data space.
 
 .. _signac: https://signac.io/
 """
+import warnings
+
 from . import environment, errors, hooks, scheduling, testing
 from .aggregates import aggregator, get_aggregate_id
 from .environment import get_environment
@@ -44,10 +46,23 @@ __all__ = [
 ]
 
 
-if _get_config_value(
+_import_packaged_environments = _get_config_value(
     "import_packaged_environments",
-    default=_FLOW_CONFIG_DEFAULTS["import_packaged_environments"],
-):
+    default=None,  # Use None to determine if this is being used or not.
+)
+
+if _import_packaged_environments is None:
+    _import_packaged_environments = _FLOW_CONFIG_DEFAULTS[
+        "import_packaged_environments"
+    ]
+else:
+    warnings.warn(
+        "Config key import_packaged_environments will be removed in signac-flow version 0.21. "
+        "Environments will always install once removed. Remove key from config to remove warning.",
+        FutureWarning,
+    )
+
+if _import_packaged_environments:
     from . import environments  # noqa: F401
 
     __all__.append("environments")

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import socket
+import warnings
 from functools import lru_cache
 
 from signac.common import config
@@ -59,7 +60,16 @@ def setup(py_modules, **attrs):
     an environment's module, but also register it with the global signac
     configuration. Once registered, the environment is automatically
     imported when the :meth:`~flow.get_environment` function is called.
+
+    Warning
+    -------
+        This function is deprecated. Install user environments manually.
     """
+    warnings.warn(
+        "Config key environment_modules will be removed in signac-flow version 0.21. "
+        "Manual install environments instead.",
+        FutureWarning,
+    )
     import setuptools
     from setuptools.command.install import install
 
@@ -517,6 +527,12 @@ def _import_configured_environments():
                 logger.warning(error)
     except KeyError:
         pass
+    else:
+        warnings.warn(
+            "Config key environment_modules will be removed  in signac-flow version 0.21. "
+            "Manual import environments instead.",
+            FutureWarning,
+        )
 
 
 def registered_environments(import_configured=True):

--- a/flow/environments/__init__.py
+++ b/flow/environments/__init__.py
@@ -1,17 +1,7 @@
 # Copyright (c) 2017 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""The environments module contains a set of provided environment profiles.
-
-These environments are imported by default. This can be disabled by setting
-the configuration key 'flow.import_packaged_environments' to 'off' with the
-following shell command:
-
-.. code-block:: bash
-
-    signac config --global set flow.import_packaged_environments off
-
-"""
+"""The environments module contains a set of provided environment profiles."""
 from . import drexel, incite, umich, umn, xsede
 
 __all__ = [

--- a/flow/util/config.py
+++ b/flow/util/config.py
@@ -10,7 +10,6 @@ _FLOW_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
-        "import_packaged_environments": {"type": "boolean"},
         "status_performance_warn_threshold": {"type": "number"},
         "show_traceback": {"type": "boolean"},
         "eligible_jobs_max_lines": {"type": "integer"},
@@ -19,7 +18,6 @@ _FLOW_SCHEMA = {
 }
 
 _FLOW_CONFIG_DEFAULTS = {
-    "import_packaged_environments": True,
     "status_performance_warn_threshold": 0.2,
     "show_traceback": False,
     "eligible_jobs_max_lines": 10,


### PR DESCRIPTION
__Note__; To merge after #651

## Description
Removes `import_packaged_environments` from the configuration.

## Motivation and Context
This is a move to make #649 simpler and our dependence on `signac`'s config to be purely at the project level in Python.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.