### PR TITLE
Simplify functions in test_util.py 

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,52 +14,78 @@ def mock_operations():
 
 
 class TestBidict:
-    def test_bidict(self):
-        # The bidict class inherits from dict, so we trust its inherited
-        # methods and only need to validate its overrides and inverse behavior.
-        bd = _bidict({"a": 1, "b": 2})
-        bd["c"] = 1
-        assert bd == {"a": 1, "c": 1, "b": 2}
-        assert bd.inverse == {1: ["a", "c"], 2: ["b"]}
-        assert len(bd) == 3
-        assert list(bd.keys()) == ["a", "b", "c"]
-        assert list(bd.values()) == [1, 2, 1]
-        assert list(bd.items()) == [("a", 1), ("b", 2), ("c", 1)]
-        assert bd.get("a") == 1
-        assert bd.get("q", 42) == 42
-        assert "a" in bd
-        assert "q" not in bd
-        del bd["c"]
-        assert bd == {"a": 1, "b": 2}
-        assert bd.inverse == {1: ["a"], 2: ["b"]}
-        assert len(bd) == 2
-        del bd["a"]
-        assert bd == {"b": 2}
-        assert bd.inverse == {2: ["b"]}
-        bd["b"] = 3
-        assert bd == {"b": 3}
-        assert bd.inverse == {3: ["b"]}
-        bd.update({"c": 2})
-        assert bd == {"b": 3, "c": 2}
-        assert bd.inverse == {2: ["c"], 3: ["b"]}
+
+    bd = _bidict({"a": 1, "b": 2})
+
+    def add_c_bidict(self):
+        self.bd["c"] = 1
+
+    def test_basic_dict(self):
+        self.add_c_bidict()
+        assert self.bd == {"a": 1, "c": 1, "b": 2}
+        assert self.bd.inverse == {1: ["a", "c"], 2: ["b"]}
+        assert len(self.bd) == 3
+        assert list(self.bd.keys()) == ["a", "b", "c"]
+        assert list(self.bd.values()) == [1, 2, 1]
+        assert list(self.bd.items()) == [("a", 1), ("b", 2), ("c", 1)]
+
+    def test_get_func(self):
+        assert self.bd.get("a") == 1
+        assert self.bd.get("q", 42) == 42
+
+    def test_belonging_func(self):
+        assert "a" in self.bd
+        assert "q" not in self.bd
+
+    def test_del_c(self):
+        self.add_c_bidict()
+        del self.bd["c"]
+        assert self.bd == {"a": 1, "b": 2}
+        assert self.bd.inverse == {1: ["a"], 2: ["b"]}
+        assert len(self.bd) == 2
+
+    def test_del_a(self):
+        del self.bd["a"]
+        assert self.bd == {"b": 2}
+        assert self.bd.inverse == {2: ["b"]}
+
+    def test_add_b(self):
+        self.bd["b"] = 3
+        assert self.bd == {"b": 3}
+        assert self.bd.inverse == {3: ["b"]}
+
+    def test_update(self):
+        self.bd.update({"c": 2})
+        assert self.bd == {"b": 3, "c": 2}
+        assert self.bd.inverse == {2: ["c"], 3: ["b"]}
+
+    def test_popitem(self):
         # Note that MutableMapping's popitem is *not* LIFO-ordered, it pops
         # according to the key iteration order (which means it defaults to FIFO
         # for the underlying dict, which is insertion-ordered).
-        assert bd.popitem() == ("b", 3)
-        assert bd == {"c": 2}
-        assert bd.inverse == {2: ["c"]}
-        bd.setdefault("c", 7)
-        assert bd == {"c": 2}
-        assert bd.inverse == {2: ["c"]}
-        bd.setdefault("a", 9)
-        assert bd == {"c": 2, "a": 9}
-        assert bd.inverse == {2: ["c"], 9: ["a"]}
-        assert bd.pop("c") == 2
-        assert bd == {"a": 9}
-        assert bd.inverse == {9: ["a"]}
-        bd.clear()
-        assert bd == {}
-        assert bd.inverse == {}
+        assert self.bd.popitem() == ("b", 3)
+        assert self.bd == {"c": 2}
+        assert self.bd.inverse == {2: ["c"]}
+
+    def test_set_default_overlap(self):
+        self.bd.setdefault("c", 7)
+        assert self.bd == {"c": 2}
+        assert self.bd.inverse == {2: ["c"]}
+
+    def test_default_no_overlap(self):
+        self.bd.setdefault("a", 9)
+        assert self.bd == {"c": 2, "a": 9}
+        assert self.bd.inverse == {2: ["c"], 9: ["a"]}
+
+    def test_pop(self):
+        assert self.bd.pop("c") == 2
+        assert self.bd == {"a": 9}
+        assert self.bd.inverse == {9: ["a"]}
+
+    def test_clear(self):
+        self.bd.clear()
+        assert self.bd == {}
+        assert self.bd.inverse == {}
 
 
 class TestTemplateFilters:
@@ -67,9 +93,11 @@ class TestTemplateFilters:
         op1 = mock_operations[0]
         op2 = mock_operations[1]
         op3 = mock_operations[2]
+
         # Test when operations run in serial
         assert calc_memory([op1], False) == 1
         assert calc_memory([op1, op2, op3], False) == 8
+
         # Test when operations run in parallel
         assert calc_memory([op1, op2], True) == 9
         assert calc_memory([op3], True) == 0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
Broke down big testing functions from test_util.py into smaller and more explicit testing functions for clarity. 
## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
All the utility tests were in one function in the class TestBidict. The changes performed involved breaking down and distributing the utility tests into more descriptive and helpful functions for the user to troubleshoot. 
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These changes address issue #626 
Since there was only one function for testing, it was unclear for the user to see what was failing in their code. These changes provides more information to the user towards what went wrong in the tests with their code. 
## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
