### PR TITLE
Move cmd and with_job to FlowProject.operation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,13 @@ Added
 +++++
 
 - The CLI ``status`` command can show document parameters by using flag ``-p doc.PARAM`` (#667).
+- ``FlowProject.operation`` now has ``cmd``, ``with_job``, and ``directives`` keyword only arguments (#679, #655, #669).
+
+Changed
++++++++
+
+- ``@flow.cmd`` and ``flow.with_job`` are deprecated (#679, #669, #665).
+- ``@FlowProject.operation.with_directives`` is deprecated (#679, #665).
 
 Version 0.21
 ============

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -355,7 +355,7 @@ class aggregator:
             )
         if getattr(func, "_flow_with_job", False):
             raise FlowProjectDefinitionError(
-                "The @flow.with_job decorator cannot be used with aggregation."
+                "The with_job option cannot be used with aggregation."
             )
         setattr(func, "_flow_aggregate", self)
         return func

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -12,6 +12,7 @@ See also: :class:`~.FlowProject`.
 """
 import inspect
 import logging
+import warnings
 from functools import wraps
 from textwrap import indent
 
@@ -42,6 +43,11 @@ def cmd(func):
         :meth:`~.FlowProject.submit` still respects directives and will prepend e.g. MPI or OpenMP
         prefixes to the shell command provided here.
     """
+    warnings.warn(
+        FutureWarning,
+        "@flow.cmd has been deprecated as of 0.22.0 and will be removed in "
+        "0.23.0. Use @FlowProject.operation(cmd=True) instead.",
+    )
     if getattr(func, "_flow_with_job", False):
         raise FlowProjectDefinitionError(
             "The @flow.cmd decorator must appear below the @flow.with_job decorator."
@@ -95,6 +101,11 @@ def with_job(func):
         def hello_cmd(job):
             return 'trap "cd `pwd`" EXIT && cd {} && echo "hello {job}"'.format(job.ws)
     """
+    warnings.warn(
+        FutureWarning,
+        "@flow.with_job has been deprecated as of 0.22.0 and will be removed in "
+        "0.23.0. Use @FlowProject.operation(with_job=True) instead.",
+    )
     if getattr(func, "_flow_aggregate", False):
         raise FlowProjectDefinitionError(
             "The @with_job decorator cannot be used with aggregation."

--- a/flow/operations.py
+++ b/flow/operations.py
@@ -44,9 +44,9 @@ def cmd(func):
         prefixes to the shell command provided here.
     """
     warnings.warn(
-        FutureWarning,
         "@flow.cmd has been deprecated as of 0.22.0 and will be removed in "
         "0.23.0. Use @FlowProject.operation(cmd=True) instead.",
+        FutureWarning,
     )
     if getattr(func, "_flow_with_job", False):
         raise FlowProjectDefinitionError(
@@ -102,9 +102,9 @@ def with_job(func):
             return 'trap "cd `pwd`" EXIT && cd {} && echo "hello {job}"'.format(job.ws)
     """
     warnings.warn(
-        FutureWarning,
         "@flow.with_job has been deprecated as of 0.22.0 and will be removed in "
         "0.23.0. Use @FlowProject.operation(with_job=True) instead.",
+        FutureWarning,
     )
     if getattr(func, "_flow_aggregate", False):
         raise FlowProjectDefinitionError(

--- a/flow/project.py
+++ b/flow/project.py
@@ -540,7 +540,7 @@ class BaseFlowOperation:
 class FlowCmdOperation(BaseFlowOperation):
     """An operation that executes a shell command.
 
-    When an operation has the ``@cmd`` directive specified, it is
+    When an operation has the ``FlowProject.operation(cmd=True)`` directive specified, it is
     instantiated as a :class:`~.FlowCmdOperation`. The operation should be a
     function of one or more positional arguments that are instances of
     :class:`~signac.contrib.job.Job`. The command (cmd) may either be a
@@ -589,7 +589,7 @@ class FlowCmdOperation(BaseFlowOperation):
 class FlowOperation(BaseFlowOperation):
     """An operation that executes a Python function.
 
-    All operations without the ``@cmd`` directive use this class. The
+    All operations without the ``FlowProject.operation(cmd=True)`` directive use this class. The
     callable ``op_func`` should be a function of one or more instances of
     :class:`~signac.contrib.job.Job`.
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -1539,6 +1539,12 @@ class _FlowProjectClass(type):
                     name and directives as an operation of the
                     :class:`~.FlowProject` subclass.
                 """
+                warnings.warn(
+                    FutureWarning,
+                    "@FlowProject.operation.with_directives has been deprecated as of 0.22.0 and "
+                    "will be removed in 0.23.0. Use @FlowProject.operation(directives={...}) "
+                    "instead.",
+                )
 
                 def add_operation_with_directives(function):
                     function._flow_directives = directives

--- a/flow/project.py
+++ b/flow/project.py
@@ -1492,7 +1492,7 @@ class _FlowProjectClass(type):
                 # wraps the original function meaning that any other labels we apply will be masked
                 # if we do this later or not even captured it not added to _OPERATION_FUNCTIONS.
                 with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", FutureWarning)
+                    warnings.simplefilter(action="ignore", category=FutureWarning)
                     if cmd:
                         _cmd(func)
                     if with_job:

--- a/flow/project.py
+++ b/flow/project.py
@@ -1446,6 +1446,8 @@ class _FlowProjectClass(type):
             with_job : bool, optional, keyword-only
                 Whether to change directories to the job workspace when running the job. Defaults to
                 ``False``.
+            directives : dict, optional, keyword-only
+                Directives to use for resource requests and execution.
 
             Returns
             -------
@@ -1455,9 +1457,13 @@ class _FlowProjectClass(type):
 
             _parent_class = parent_class
 
-            def __call__(self, func, name=None, *, cmd=False, with_job=False):
+            def __call__(
+                self, func, name=None, *, cmd=False, with_job=False, directives=None
+            ):
                 if isinstance(func, str):
-                    return lambda op: self(op, name=func, cmd=cmd, with_job=with_job)
+                    return lambda op: self(
+                        op, name=func, cmd=cmd, with_job=with_job, directives=directives
+                    )
 
                 if func in chain(
                     *self._parent_class._OPERATION_PRECONDITIONS.values(),
@@ -1466,6 +1472,9 @@ class _FlowProjectClass(type):
                     raise FlowProjectDefinitionError(
                         "A condition function cannot be used as an operation."
                     )
+
+                # Store directives
+                self._flow_directives = {} if directives is None else directives
 
                 if name is None:
                     name = func.__name__

--- a/flow/project.py
+++ b/flow/project.py
@@ -1458,13 +1458,27 @@ class _FlowProjectClass(type):
             _parent_class = parent_class
 
             def __call__(
-                self, func, name=None, *, cmd=False, with_job=False, directives=None
+                self,
+                func=None,
+                name=None,
+                *,
+                cmd=False,
+                with_job=False,
+                directives=None,
             ):
                 if isinstance(func, str):
-                    return lambda op: self(
+                    return lambda op: self._internal_call(
                         op, name=func, cmd=cmd, with_job=with_job, directives=directives
                     )
+                if func is None:
+                    return lambda op: self._internal_call(
+                        op, name=name, cmd=cmd, with_job=with_job, directives=directives
+                    )
+                return self._internal_call(
+                    func, name=name, cmd=cmd, with_job=with_job, directives=directives
+                )
 
+            def _internal_call(self, func, name, *, cmd, with_job, directives):
                 if func in chain(
                     *self._parent_class._OPERATION_PRECONDITIONS.values(),
                     *self._parent_class._OPERATION_POSTCONDITIONS.values(),
@@ -1473,8 +1487,20 @@ class _FlowProjectClass(type):
                         "A condition function cannot be used as an operation."
                     )
 
+                # Handle cmd and with_job options. Use the deprecated decorators internally until
+                # the decorators are removed. These must be done first for now as with_job actually
+                # wraps the original function meaning that any other labels we apply will be masked
+                # if we do this later or not even captured it not added to _OPERATION_FUNCTIONS.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", FutureWarning)
+                    if cmd:
+                        _cmd(func)
+                    if with_job:
+                        func = _with_job(func)
+
                 # Store directives
-                self._flow_directives = {} if directives is None else directives
+                if directives is not None:
+                    func._flow_directives = directives
 
                 if name is None:
                     name = func.__name__
@@ -1498,15 +1524,6 @@ class _FlowProjectClass(type):
 
                 if not getattr(func, "_flow_aggregate", False):
                     func._flow_aggregate = aggregator.groupsof(1)
-
-                # Handle cmd and with_job options. Use the deprecated decorators internally until
-                # the decorators are removed.
-                with warnings.catch_warnings:
-                    warnings.simplefilter("ignore:FutureWarnings")
-                    if with_job:
-                        _with_job(func)
-                    if cmd:
-                        _cmd(func)
 
                 # Append the name and function to the class registry
                 self._parent_class._OPERATION_FUNCTIONS.append((name, func))
@@ -1549,10 +1566,10 @@ class _FlowProjectClass(type):
                     :class:`~.FlowProject` subclass.
                 """
                 warnings.warn(
-                    FutureWarning,
                     "@FlowProject.operation.with_directives has been deprecated as of 0.22.0 and "
                     "will be removed in 0.23.0. Use @FlowProject.operation(directives={...}) "
                     "instead.",
+                    FutureWarning,
                 )
 
                 def add_operation_with_directives(function):

--- a/tests/define_aggregate_test_project.py
+++ b/tests/define_aggregate_test_project.py
@@ -1,4 +1,4 @@
-from flow import FlowProject, aggregator, cmd
+from flow import FlowProject, aggregator
 
 
 class _AggregateTestProject(FlowProject):
@@ -28,8 +28,7 @@ def op1(job):
     pass
 
 
-@_AggregateTestProject.operation
-@cmd
+@_AggregateTestProject.operation(cmd=True)
 @aggregator.groupby("even")
 def agg_op_parallel(*jobs):
     # This is used to test parallel execution of aggregation operations
@@ -71,8 +70,7 @@ def agg_op3(*jobs):
     set_all_job_docs(jobs, "op3", True)
 
 
-@_AggregateTestProject.operation
-@cmd
+@_AggregateTestProject.operation(cmd=True)
 @aggregator(sort_by="i", select=lambda job: job.sp.i <= 2)
 def agg_op4(*jobs):
     return "echo '{jobs[0].sp.i} and {jobs[1].sp.i}'"

--- a/tests/define_directives_test_project.py
+++ b/tests/define_directives_test_project.py
@@ -11,21 +11,19 @@ group = _DirectivesTestProject.make_group(name="walltimegroup")
 
 
 @group
-@_DirectivesTestProject.operation.with_directives({"walltime": 1.0})
+@_DirectivesTestProject.operation(directives={"walltime": 1.0})
 def op_walltime(job):
     pass
 
 
 @group
-@_DirectivesTestProject.operation.with_directives({"walltime": None})
+@_DirectivesTestProject.operation(directives={"walltime": None})
 def op_walltime_2(job):
     pass
 
 
 @group
-@_DirectivesTestProject.operation.with_directives(
-    {"walltime": datetime.timedelta(hours=2)}
-)
+@_DirectivesTestProject.operation(directives={"walltime": datetime.timedelta(hours=2)})
 def op_walltime_3(job):
     pass
 

--- a/tests/define_hooks_test_project.py
+++ b/tests/define_hooks_test_project.py
@@ -1,4 +1,3 @@
-import flow
 from flow import FlowProject
 
 HOOKS_ERROR_MESSAGE = "You raised an error! Hooray!"
@@ -41,9 +40,7 @@ def base(job):
 @_HooksTestProject.operation_hooks.on_exit(set_job_doc(HOOK_KEYS[1]))
 @_HooksTestProject.operation_hooks.on_success(set_job_doc(HOOK_KEYS[2]))
 @_HooksTestProject.operation_hooks.on_exception(set_job_doc_with_error())
-@_HooksTestProject.operation
-@flow.with_job
-@flow.cmd
+@_HooksTestProject.operation(cmd=True, with_job=True)
 def base_cmd(job):
     if job.sp.raise_exception:
         return "exit 42"
@@ -57,9 +54,7 @@ def base_no_decorators(job):
         raise RuntimeError(HOOKS_ERROR_MESSAGE)
 
 
-@_HooksTestProject.operation
-@flow.with_job
-@flow.cmd
+@_HooksTestProject.operation(cmd=True, with_job=True)
 def base_cmd_no_decorators(job):
     if job.sp.raise_exception:
         return "exit 42"
@@ -74,9 +69,7 @@ def raise_exception_in_hook(job):
 
 
 @_HooksTestProject.operation_hooks.on_start(raise_error)
-@_HooksTestProject.operation
-@flow.with_job
-@flow.cmd
+@_HooksTestProject.operation(cmd=True, with_job=True)
 def raise_exception_in_hook_cmd(job):
     pass
 

--- a/tests/define_status_test_project.py
+++ b/tests/define_status_test_project.py
@@ -1,6 +1,5 @@
 import os
 
-import flow
 from flow import FlowProject
 
 
@@ -35,9 +34,8 @@ def b_is_even(job):
         return False
 
 
-@flow.cmd
 @group1
-@_TestProject.operation
+@_TestProject.operation(cmd=True)
 @_TestProject.pre(b_is_even)
 @_TestProject.post.isfile("world.txt")
 def op1(job):

--- a/tests/define_template_test_project.py
+++ b/tests/define_template_test_project.py
@@ -71,7 +71,6 @@ def walltime_op(job):
     pass
 
 
-@TestProject.operation
-@flow.cmd
+@TestProject.operation(cmd=True)
 def multiline_cmd(job):
     return 'echo "First line"\necho "Second line"'

--- a/tests/define_template_test_project.py
+++ b/tests/define_template_test_project.py
@@ -20,50 +20,53 @@ def serial_op(job):
 
 
 @group1
-@TestProject.operation.with_directives({"np": TestProject.np})
+@TestProject.operation(directives={"np": TestProject.np})
 def parallel_op(job):
     pass
 
 
-@TestProject.operation.with_directives({"nranks": TestProject.nranks})
+@TestProject.operation(directives={"nranks": TestProject.nranks})
 def mpi_op(job):
     pass
 
 
-@TestProject.operation.with_directives({"omp_num_threads": TestProject.omp_num_threads})
+@TestProject.operation(directives={"omp_num_threads": TestProject.omp_num_threads})
 def omp_op(job):
     pass
 
 
-@TestProject.operation.with_directives(
-    {"nranks": TestProject.nranks, "omp_num_threads": TestProject.omp_num_threads}
+@TestProject.operation(
+    directives={
+        "nranks": TestProject.nranks,
+        "omp_num_threads": TestProject.omp_num_threads,
+    }
 )
 def hybrid_op(job):
     pass
 
 
-@TestProject.operation.with_directives(
-    {"ngpu": TestProject.ngpu, "nranks": TestProject.ngpu}
+@TestProject.operation(
+    directives={"ngpu": TestProject.ngpu, "nranks": TestProject.ngpu}
 )
 def gpu_op(job):
     pass
 
 
-@TestProject.operation.with_directives(
-    {"ngpu": TestProject.ngpu, "nranks": TestProject.nranks}
+@TestProject.operation(
+    directives={"ngpu": TestProject.ngpu, "nranks": TestProject.nranks}
 )
 def mpi_gpu_op(job):
     pass
 
 
 @group1
-@TestProject.operation.with_directives({"memory": TestProject.memory})
+@TestProject.operation(directives={"memory": TestProject.memory})
 def memory_op(job):
     pass
 
 
 @group1
-@TestProject.operation.with_directives({"walltime": TestProject.walltime})
+@TestProject.operation(directives={"walltime": TestProject.walltime})
 def walltime_op(job):
     pass
 

--- a/tests/define_test_project.py
+++ b/tests/define_test_project.py
@@ -1,6 +1,5 @@
 import os
 
-import flow
 from flow import FlowProject
 
 
@@ -36,16 +35,16 @@ def b_is_even(job):
 
 
 @group1
-@_TestProject.operation.with_directives(
-    {
+@_TestProject.operation(
+    cmd=True,
+    directives={
         # Explicitly set a "bad" directive that is unused by the template.
         # The submit interface should warn about unused directives.
         "bad_directive": 0,
         # But not this one:
         "np": 1,
-    }
+    },
 )
-@flow.cmd
 @_TestProject.pre(b_is_even)
 @_TestProject.post.isfile("world.txt")
 def op1(job):
@@ -57,14 +56,14 @@ def _need_to_fork(job):
 
 
 @group1
-@_TestProject.operation.with_directives({"fork": _need_to_fork})
+@_TestProject.operation(directives={"fork": _need_to_fork})
 @_TestProject.post.true("test")
 def op2(job):
     job.document.test = os.getpid()
 
 
 @group2.with_directives(dict(omp_num_threads=4))
-@_TestProject.operation.with_directives({"ngpu": 1, "omp_num_threads": 1})
+@_TestProject.operation(directives={"ngpu": 1, "omp_num_threads": 1})
 @_TestProject.post.true("test3_true")
 @_TestProject.post.false("test3_false")
 @_TestProject.post.not_(lambda job: job.doc.test3_false)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -393,6 +393,7 @@ class TestProjectClass(TestProjectBase):
             def op2(job):
                 pass
 
+    @pytest.mark.filterwarnings("ignore:@flow.with_job")
     @pytest.mark.filterwarnings("ignore:@flow.cmd")
     def test_cmd_with_job_invalid_ordering(self):
         class A(FlowProject):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -343,8 +343,7 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation
-        @with_job
+        @A.operation(with_job=True)
         def test_context(job):
             assert os.path.realpath(os.getcwd()) == os.path.realpath(job.ws)
 
@@ -356,6 +355,7 @@ class TestProjectClass(TestProjectBase):
                     project.run()
                 assert os.getcwd() == starting_dir
 
+    @pytest.mark.filterwarnings("ignore:@flow.cmd")
     def test_cmd_decorator_with_cmd_argument(self):
         class A(FlowProject):
             pass
@@ -374,6 +374,7 @@ class TestProjectClass(TestProjectBase):
             def op2(job):
                 pass
 
+    @pytest.mark.filterwarnings("ignore:@flow.with_job")
     def test_with_job_decorator_with_with_job_argument(self):
         class A(FlowProject):
             pass
@@ -392,6 +393,7 @@ class TestProjectClass(TestProjectBase):
             def op2(job):
                 pass
 
+    @pytest.mark.filterwarnings("ignore:@flow.cmd")
     def test_cmd_with_job_invalid_ordering(self):
         class A(FlowProject):
             pass
@@ -401,20 +403,6 @@ class TestProjectClass(TestProjectBase):
             @A.operation(cmd=True)
             @with_job
             def op1(job):
-                pass
-
-        with pytest.raises(FlowProjectDefinitionError):
-
-            @with_job
-            @A.operation(cmd=True)
-            def op2(job):
-                pass
-
-        with pytest.raises(FlowProjectDefinitionError):
-
-            @A.operation(with_job=True)
-            @cmd
-            def op3(job):
                 pass
 
         with pytest.raises(FlowProjectDefinitionError):
@@ -436,9 +424,7 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation
-        @with_job
-        @cmd
+        @A.operation(cmd=True, with_job=True)
         def test_context(job):
             return "echo 'hello' > world.txt"
 
@@ -473,8 +459,7 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation
-        @with_job
+        @A.operation(with_job=True)
         def test_context(job):
             raise Exception
 
@@ -491,9 +476,7 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation
-        @with_job
-        @cmd
+        @A.operation(cmd=True, with_job=True)
         def test_context(job):
             return "exit 1"
 
@@ -510,8 +493,8 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation.with_directives(
-            {"executable": lambda job: f"mpirun -np {job.doc.np} python"}
+        @A.operation(
+            directives={"executable": lambda job: f"mpirun -np {job.doc.np} python"}
         )
         def test_context(job):
             return "exit 1"
@@ -529,7 +512,7 @@ class TestProjectClass(TestProjectBase):
             class A(FlowProject):
                 pass
 
-            @A.operation.with_directives({"memory": value})
+            @A.operation(directives={"memory": value})
             def op1(job):
                 pass
 
@@ -557,7 +540,7 @@ class TestProjectClass(TestProjectBase):
             class A(FlowProject):
                 pass
 
-            @A.operation.with_directives({"memory": value})
+            @A.operation(directives={"memory": value})
             def op1(job):
                 pass
 
@@ -582,7 +565,7 @@ class TestProjectClass(TestProjectBase):
             class A(FlowProject):
                 pass
 
-            @A.operation.with_directives({"walltime": value})
+            @A.operation(directives={"walltime": value})
             def op1(job):
                 pass
 
@@ -600,7 +583,7 @@ class TestProjectClass(TestProjectBase):
             class A(FlowProject):
                 pass
 
-            @A.operation.with_directives({"walltime": value})
+            @A.operation(directives={"walltime": value})
             def op1(job):
                 pass
 
@@ -623,8 +606,8 @@ class TestProjectClass(TestProjectBase):
         class A(FlowProject):
             pass
 
-        @A.operation.with_directives(
-            {
+        @A.operation(
+            directives={
                 "nranks": lambda job: job.doc.get("nranks", 1),
                 "omp_num_threads": lambda job: job.doc.get("omp_num_threads", 1),
             }
@@ -691,8 +674,8 @@ class TestProjectClass(TestProjectBase):
         group = A.make_group("group")
 
         @group
-        @A.operation.with_directives(
-            {
+        @A.operation(
+            directives={
                 "nranks": lambda job: job.doc.get("nranks", 1),
                 "omp_num_threads": lambda job: job.doc.get("omp_num_threads", 1),
             }
@@ -701,8 +684,8 @@ class TestProjectClass(TestProjectBase):
             return "hello!"
 
         @group
-        @A.operation.with_directives(
-            {
+        @A.operation(
+            directives={
                 "nranks": lambda job: job.doc.get("nranks", 1),
                 "omp_num_threads": lambda job: job.doc.get("omp_num_threads", 1),
             }
@@ -724,6 +707,7 @@ class TestProjectClass(TestProjectBase):
             not callable(value) for value in submit_job_operation.directives.values()
         )
 
+    @pytest.mark.filterwarnings("ignore:@FlowProject.operation.with_directives")
     def test_operation_with_directives(self):
         class A(FlowProject):
             pass
@@ -2227,9 +2211,8 @@ class TestAggregatesProjectUtilities(TestAggregatesProjectBase):
 
         with pytest.raises(FlowProjectDefinitionError):
 
-            @A.operation
             @aggregator()
-            @with_job
+            @A.operation(with_job=True)
             def test_invalid_decorators(job):
                 pass
 
@@ -2239,9 +2222,8 @@ class TestAggregatesProjectUtilities(TestAggregatesProjectBase):
 
         with pytest.raises(FlowProjectDefinitionError):
 
-            @A.operation
-            @with_job
             @aggregator()
+            @A.operation(with_job=True)
             def test_invalid_decorators(job):
                 pass
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -356,16 +356,80 @@ class TestProjectClass(TestProjectBase):
                     project.run()
                 assert os.getcwd() == starting_dir
 
-    def test_cmd_with_job_wrong_order(self):
+    def test_cmd_decorator_with_cmd_argument(self):
         class A(FlowProject):
             pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @A.operation(cmd=True)
+            @cmd
+            def op1(job):
+                pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @cmd
+            @A.operation(cmd=True)
+            def op2(job):
+                pass
+
+    def test_with_job_decorator_with_with_job_argument(self):
+        class A(FlowProject):
+            pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @A.operation(with_job=True)
+            @with_job
+            def op1(job):
+                pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @with_job
+            @A.operation(with_job=True)
+            def op2(job):
+                pass
+
+    def test_cmd_with_job_invalid_ordering(self):
+        class A(FlowProject):
+            pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @A.operation(cmd=True)
+            @with_job
+            def op1(job):
+                pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @with_job
+            @A.operation(cmd=True)
+            def op2(job):
+                pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @A.operation(with_job=True)
+            @cmd
+            def op3(job):
+                pass
+
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @cmd
+            @A.operation(with_job=True)
+            def op4(job):
+                pass
 
         with pytest.raises(FlowProjectDefinitionError):
 
             @A.operation
             @cmd
             @with_job
-            def test_cmd(job):
+            def op5(job):
                 pass
 
     def test_with_job_works_with_cmd(self):


### PR DESCRIPTION
## Description
Does not break current behavior.

- refactor: Deprecate cmd and with_job decorators.
- feat: Add cmd and with_job keyword only arguments for @operation
- test: Add tests for new keyword only arguments of FlowProject.operation

## Motivation and Context
Closes #669
and replaces #671.

I had large suggestions to the way the code should be changed. I think this is much simpler to get the desired behavior.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
