### PR TITLE
Move aggregator to keyword argument in operation decorator

### DIFF
--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -46,7 +46,7 @@ def _get_unique_function_id(func):
 
 
 class aggregator:
-    """Decorator for operation functions that operate on aggregates.
+    """Class for generating aggregates for use in operations.
 
     By default, if the ``aggregator_function`` is ``None``, an aggregate of all
     jobs will be created.
@@ -58,8 +58,7 @@ class aggregator:
 
     .. code-block:: python
 
-        @aggregator()
-        @FlowProject.operation
+        @FlowProject.operation(aggregator=aggregator())
         def foo(*jobs):
             print(len(jobs))
 
@@ -134,8 +133,7 @@ class aggregator:
 
         .. code-block:: python
 
-            @aggregator.groupsof(num=2)
-            @FlowProject.operation
+            @FlowProject.operation(aggregator=aggregator.groupsof(num=2))
             def foo(*jobs):
                 print(len(jobs))
 
@@ -199,8 +197,7 @@ class aggregator:
 
         .. code-block:: python
 
-            @aggregator.groupby(key="key", default=-1)
-            @FlowProject.operation
+            @FlowProject.operation(aggegator=aggregator.groupby(key="key", default=-1))
             def foo(*jobs):
                 print(len(jobs))
 

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -197,7 +197,7 @@ class aggregator:
 
         .. code-block:: python
 
-            @FlowProject.operation(aggegator=aggregator.groupby(key="key", default=-1))
+            @FlowProject.operation(aggregator=aggregator.groupby(key="key", default=-1))
             def foo(*jobs):
                 print(len(jobs))
 
@@ -348,7 +348,7 @@ class aggregator:
         """
         _deprecated_warning(
             deprecation="@aggregator(...)",
-            alternative="Use FlowProject.operation(aggregator=aggegator) instead.",
+            alternative="Use FlowProject.operation(aggregator=aggregator(...)) instead.",
             deprecated_in="0.23.0",
             removed_in="0.24.0",
         )

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -13,6 +13,7 @@ from collections.abc import Collection, Iterable, Mapping
 from hashlib import md5
 
 from .errors import FlowProjectDefinitionError
+from .util.misc import _deprecated_warning
 
 
 def _get_unique_function_id(func):
@@ -348,6 +349,12 @@ class aggregator:
             The function to decorate.
 
         """
+        _deprecated_warning(
+            deprecation="@aggregator(...)",
+            alternative="Use FlowProject.operation(aggregator=aggegator) instead.",
+            deprecated_in="0.23.0",
+            removed_in="0.24.0",
+        )
         if not callable(func):
             raise FlowProjectDefinitionError(
                 "Invalid argument passed while calling the aggregate "
@@ -356,6 +363,11 @@ class aggregator:
         if getattr(func, "_flow_with_job", False):
             raise FlowProjectDefinitionError(
                 "The with_job option cannot be used with aggregation."
+            )
+        current_agg = getattr(func, "_flow_aggregate", None)
+        if current_agg is not None and current_agg != aggregator.groupsof(1):
+            raise FlowProjectDefinitionError(
+                "Cannot specify aggregates in function and decorator."
             )
         setattr(func, "_flow_aggregate", self)
         return func

--- a/flow/project.py
+++ b/flow/project.py
@@ -1487,6 +1487,9 @@ class _FlowProjectClass(type):
                 ``False``.
             directives : dict, optional, keyword-only
                 Directives to use for resource requests and execution.
+            aggregator : flow.aggregator, optional, keyword-only
+                The aggregator to use for the operation. Default value uses aggregator of size one
+                (i.e. individual jobs).
 
             Returns
             -------

--- a/flow/project.py
+++ b/flow/project.py
@@ -68,6 +68,7 @@ from .util.misc import (
     _add_cwd_to_environment_pythonpath,
     _bidict,
     _cached_partial,
+    _deprecated_warning,
     _get_parallel_executor,
     _positive_int,
     _roundrobin,
@@ -615,10 +616,11 @@ class FlowCmdOperation(BaseFlowOperation):
                     format_arguments[match.group(1)] = jobs
             formatted_cmd = cmd.format(**format_arguments)
         if formatted_cmd != cmd:
-            warnings.warn(
-                "Returning format strings in a cmd operation is deprecated as of version 0.22.0 "
-                "and will be removed in  0.23.0. Users should format the command string.",
-                FutureWarning,
+            _deprecated_warning(
+                "Returning format strings in a cmd operation",
+                "Users should format the command string.",
+                "0.22.0",
+                "0.23.0",
             )
         return formatted_cmd
 
@@ -1602,11 +1604,11 @@ class _FlowProjectClass(type):
                     name and directives as an operation of the
                     :class:`~.FlowProject` subclass.
                 """
-                warnings.warn(
-                    "@FlowProject.operation.with_directives has been deprecated as of 0.22.0 and "
-                    "will be removed in 0.23.0. Use @FlowProject.operation(directives={...}) "
-                    "instead.",
-                    FutureWarning,
+                _deprecated_warning(
+                    "@FlowProject.operation.with_directives",
+                    "Use @FlowProject.operation(directives={...}) instead.",
+                    "0.22.0",
+                    "0.23.0",
                 )
 
                 def add_operation_with_directives(function):
@@ -5153,10 +5155,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             sys.exit(2)
 
         if args.show_traceback:
-            warnings.warn(
-                "--show-traceback is deprecated and to be removed in signac-flow version 0.23.",
-                FutureWarning,
-            )
+            _deprecated_warning("--show-traceback", "", "0.22.0", "0.23.0")
 
         # Manually 'merge' the various global options defined for both the main parser
         # and the parent parser that are shared by all subparsers:

--- a/flow/project.py
+++ b/flow/project.py
@@ -617,10 +617,10 @@ class FlowCmdOperation(BaseFlowOperation):
             formatted_cmd = cmd.format(**format_arguments)
         if formatted_cmd != cmd:
             _deprecated_warning(
-                "Returning format strings in a cmd operation",
-                "Users should format the command string.",
-                "0.22.0",
-                "0.23.0",
+                deprecation="Returning format strings in a cmd operation",
+                alternative="Users should format the command string.",
+                deprecated_in="0.22.0",
+                removed_in="0.23.0",
             )
         return formatted_cmd
 
@@ -1634,10 +1634,10 @@ class _FlowProjectClass(type):
                     :class:`~.FlowProject` subclass.
                 """
                 _deprecated_warning(
-                    "@FlowProject.operation.with_directives",
-                    "Use @FlowProject.operation(directives={...}) instead.",
-                    "0.22.0",
-                    "0.23.0",
+                    deprecation="@FlowProject.operation.with_directives",
+                    alternative="Use @FlowProject.operation(directives={...}) instead.",
+                    deprecated_in="0.22.0",
+                    removed_in="0.23.0",
                 )
 
                 def add_operation_with_directives(function):
@@ -5184,7 +5184,12 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
             sys.exit(2)
 
         if args.show_traceback:
-            _deprecated_warning("--show-traceback", "", "0.22.0", "0.23.0")
+            _deprecated_warning(
+                deprecation="--show-traceback",
+                alternative="",
+                deprecated_in="0.22.0",
+                removed_in="0.23.0",
+            )
 
         # Manually 'merge' the various global options defined for both the main parser
         # and the parent parser that are shared by all subparsers:

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -400,7 +400,7 @@ def _deprecated_warning(
     alternative: str,
     deprecated_in: str,
     removed_in: str,
-    category: "Warning" = FutureWarning,
+    category: Warning = FutureWarning,
 ):
     warnings.warn(
         " ".join(

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -395,6 +395,7 @@ def _get_parallel_executor(parallelization="none"):
 
 
 def _deprecated_warning(
+    *,
     deprecation: str,
     alternative: str,
     deprecated_in: str,

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -414,6 +414,7 @@ def _deprecated_warning(
             )
         ),
         category,
+        stacklevel=2,
     )
 
 

--- a/flow/util/misc.py
+++ b/flow/util/misc.py
@@ -5,6 +5,7 @@
 import argparse
 import logging
 import os
+import warnings
 from collections.abc import MutableMapping
 from contextlib import contextmanager
 from functools import lru_cache, partial
@@ -391,6 +392,28 @@ def _get_parallel_executor(parallelization="none"):
             return list(tmap(func, iterable, tqdm_class=tqdm, **kwargs))
 
     return parallel_executor
+
+
+def _deprecated_warning(
+    deprecation: str,
+    alternative: str,
+    deprecated_in: str,
+    removed_in: str,
+    category: "Warning" = FutureWarning,
+):
+    warnings.warn(
+        " ".join(
+            (
+                deprecation,
+                "has been deprecated as of",
+                deprecated_in,
+                "and will be removed in",
+                removed_in + ".",
+                alternative,
+            )
+        ),
+        category,
+    )
 
 
 __all__ = [

--- a/tests/define_aggregate_test_project.py
+++ b/tests/define_aggregate_test_project.py
@@ -28,50 +28,49 @@ def op1(job):
     pass
 
 
-@_AggregateTestProject.operation(cmd=True)
-@aggregator.groupby("even")
+@_AggregateTestProject.operation(cmd=True, aggregator=aggregator.groupby("even"))
 def agg_op_parallel(*jobs):
     # This is used to test parallel execution of aggregation operations
     return f"echo '{len(jobs)}'"
 
 
-@_AggregateTestProject.operation
-@aggregator.groupby("even")
+@_AggregateTestProject.operation(aggregator=aggregator.groupby("even"))
 def agg_op1(*jobs):
     total = sum(job.sp.i for job in jobs)
     set_all_job_docs(jobs, "sum", total)
 
 
-@_AggregateTestProject.operation
-@aggregator.groupby(lambda job: job.sp.i % 2)
+@_AggregateTestProject.operation(
+    aggregator=aggregator.groupby(lambda job: job.sp.i % 2)
+)
 def agg_op1_different(*jobs):
     sum_other = sum(job.sp.i for job in jobs)
     set_all_job_docs(jobs, "sum_other", sum_other)
 
 
-@_AggregateTestProject.operation
-@aggregator(statepoint_i_even_odd_aggregator)
+@_AggregateTestProject.operation(
+    aggregator=aggregator(statepoint_i_even_odd_aggregator)
+)
 def agg_op1_custom(*jobs):
     sum_custom = sum(job.sp.i for job in jobs)
     set_all_job_docs(jobs, "sum_custom", sum_custom)
 
 
 @group1
-@_AggregateTestProject.operation
-@aggregator.groupsof(30)
+@_AggregateTestProject.operation(aggregator=aggregator.groupsof(30))
 def agg_op2(*jobs):
     set_all_job_docs(jobs, "op2", True)
 
 
 @group1
-@_AggregateTestProject.operation
-@aggregator()
+@_AggregateTestProject.operation(aggregator=aggregator())
 def agg_op3(*jobs):
     set_all_job_docs(jobs, "op3", True)
 
 
-@_AggregateTestProject.operation(cmd=True)
-@aggregator(sort_by="i", select=lambda job: job.sp.i <= 2)
+@_AggregateTestProject.operation(
+    cmd=True, aggregator=aggregator(sort_by="i", select=lambda job: job.sp.i <= 2)
+)
 def agg_op4(*jobs):
     return "echo '{jobs[0].sp.i} and {jobs[1].sp.i}'"
 

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -7,6 +7,8 @@ from conftest import TestProjectBase
 from flow.aggregates import aggregator, get_aggregate_id
 from flow.errors import FlowProjectDefinitionError
 
+ignore_call_warning = pytest.mark.filterwarnings("ignore:@aggregator():FutureWarning")
+
 
 class AggregateProjectSetup(TestProjectBase):
     project_name = "AggregateTestProject"
@@ -311,17 +313,20 @@ class TestAggregate(AggregateProjectSetup, AggregateFixtures):
         with pytest.raises(TypeError):
             aggregator(select=select)
 
+    @ignore_call_warning
     @pytest.mark.parametrize("param", ["str", 1, None])
     def test_invalid_call(self, param):
         aggregator_instance = aggregator()
         with pytest.raises(FlowProjectDefinitionError):
             aggregator_instance(param)
 
+    @ignore_call_warning
     def test_call_without_argument(self):
         aggregate_instance = aggregator()
         with pytest.raises(FlowProjectDefinitionError):
             aggregate_instance()
 
+    @ignore_call_warning
     def test_call_with_decorator(self):
         @aggregator()
         def test_function(x):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2245,6 +2245,7 @@ class TestAggregatesProjectUtilities(TestAggregatesProjectBase):
         # The operation agg_op2 adds another aggregate in the project.
         assert len(agg_cursor) == NUM_BEFORE_REREGISTRATION + 2
 
+    @pytest.mark.filterwarnings("ignore:@aggregator():FutureWarning")
     def test_aggregator_with_job(self):
         class A(FlowProject):
             pass
@@ -2256,15 +2257,17 @@ class TestAggregatesProjectUtilities(TestAggregatesProjectBase):
             def test_invalid_decorators(job):
                 pass
 
-    def test_with_job_aggregator(self):
-        class A(FlowProject):
-            pass
+        with pytest.raises(FlowProjectDefinitionError):
+
+            @A.operation(with_job=True)
+            @aggregator()
+            def test_invalid_decorators_2(job):
+                pass
 
         with pytest.raises(FlowProjectDefinitionError):
 
-            @aggregator()
-            @A.operation(with_job=True)
-            def test_invalid_decorators(job):
+            @A.operation(with_job=True, aggregator=aggregator())
+            def test_invalid_decorator_combination(job):
                 pass
 
 


### PR DESCRIPTION
## Description
Aggregators are now preferentially specified in the `@FlowProject.operation` decorator.
- refactor: Standardize future(deprecation) warnings
- feat: Add aggregator argument to FlowProject.operation
- test: Update tests with new FlowProject.operation

## Motivation and Context
This continues the move of operation registration is operation definition.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
