### PR TITLE
fix: Update NCSA Delta GPU hostname to env regex

### DIFF
--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -212,8 +212,9 @@ class DeltaEnvironment(DefaultSlurmEnvironment):
 
     # Example hostnames
     # login: dt-login02.delta.internal.ncsa.edu
-    # host: cn001.delta.internal.ncsa.edu
-    hostname_pattern = r"(dt|cn)(-login)?[0-9]+\.delta\.internal\.ncsa\.edu"
+    # cpu host: cn001.delta.internal.ncsa.edu
+    # gpu host: gpua075.delta.internal.ncsa.edu
+    hostname_pattern = r"(gpua|dt|cn)(-login)?[0-9]+\.delta\.internal\.ncsa\.edu"
     template = "delta.sh"
     cores_per_node = 128
 


### PR DESCRIPTION
## Description
Adds to the `Delta` hostname regular expression to correctly detect the Delta environment on a GPU node.

## Motivation and Context
Currently we fall back to the `DefaultSlurmEnvironment` on Delta GPU nodes which can cause errors if some logic is environment dependent.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
