### PR TITLE
Update flow for signac 1.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,6 @@ jobs:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
       PYTHON: python
-  linux-python-310-signac-next:
-    <<: *test-template
-    environment:
-      DEPENDENCIES: "NEWEST"
-      SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git@next"
-      PYTHON: python
   linux-python-39:
     <<: *test-template
     docker:
@@ -236,7 +230,6 @@ workflows:
                 - master
     jobs:
       - linux-python-310-signac-latest
-#     - linux-python-310-signac-next
       - test-install-pip-python-310
       - test-install-pip-python-39
       - test-install-pip-python-38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,6 @@ jobs:
           path: test-reports
           destination: test-reports
 
-  linux-python-310-signac-16:
-    <<: *test-template
-    environment:
-      DEPENDENCIES: "NEWEST"
-      SIGNAC_VERSION: "signac~=1.6.0"
-      PYTHON: python
-  linux-python-310-signac-15:
-    <<: *test-template
-    environment:
-      DEPENDENCIES: "NEWEST"
-      SIGNAC_VERSION: "signac~=1.5.0"
-      PYTHON: python
   linux-python-310-signac-latest:
     <<: *test-template
     environment:
@@ -95,7 +83,7 @@ jobs:
       - image: cimg/python:3.8
     environment:
       DEPENDENCIES: "OLDEST"
-      SIGNAC_VERSION: "signac==1.3.0"
+      SIGNAC_VERSION: "signac==1.8.0"
       PYTHON: python
 
   test-install-pip-python-310: &test-install-pip
@@ -225,16 +213,6 @@ workflows:
       - linux-python-38-oldest:
           post-steps:
             - codecov/upload
-      - linux-python-310-signac-16:
-          requires:
-            - linux-python-310
-          post-steps:
-            - codecov/upload
-      - linux-python-310-signac-15:
-          requires:
-            - linux-python-310
-          post-steps:
-            - codecov/upload
       - check-metadata:
           filters:
             branches:
@@ -248,8 +226,6 @@ workflows:
             - linux-python-39
             - linux-python-38
             - linux-python-38-oldest
-            - linux-python-310-signac-16
-            - linux-python-310-signac-15
   nightly:
     triggers:
       - schedule:

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,11 @@ Version 0.23
 
 [0.23.0] -- 20xx-xx-xx
 
+Changed
++++++++
+
+- Deprecated ``alias`` CLI argument to ``flow init`` (#693).
+
 Fixed
 +++++
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Version 0.23
 Changed
 +++++++
 
+- Require ``signac`` version 1.8.0 (#693).
 - Deprecated ``alias`` CLI argument to ``flow init`` (#693).
 
 Fixed

--- a/doc/doc-project.py
+++ b/doc/doc-project.py
@@ -6,4 +6,4 @@ class DocumentationProject(flow.FlowProject):
 
 
 if __name__ == "__main__":
-    DocumentationProject.init_project("DocumentationProject").main()
+    DocumentationProject.init_project().main()

--- a/flow/__main__.py
+++ b/flow/__main__.py
@@ -120,7 +120,7 @@ def main():
         type=str,
         nargs="?",
         default="",
-        help="Unused will be removed in flow 0.24.0.",
+        help="Unused, will be removed in flow 0.24.0.",
     )
     parser_init.add_argument(
         "-t",

--- a/flow/__main__.py
+++ b/flow/__main__.py
@@ -19,6 +19,7 @@ import jinja2
 from signac import get_project, init_project
 
 from . import __version__, environment, template
+from .util.misc import _deprecated_warning
 
 logger = logging.getLogger(__name__)
 
@@ -28,22 +29,20 @@ def main_init(args):
 
     The available templates are defined in the template module.
     """
-    if not args.alias.isidentifier():
-        raise ValueError(
-            "The alias '{}' is not a valid Python identifier and can therefore "
-            "not be used as a FlowProject alias.".format(args.alias)
-        )
     try:
         get_project()
     except LookupError:
-        init_project(name=args.alias)
-        print(
-            "Initialized signac project with name '{}' in "
-            "current directory.".format(args.alias),
-            file=sys.stderr,
-        )
+        if args.alias != "":
+            _deprecated_warning(
+                deprecation="alias",
+                alternative="",
+                deprecated_in="0.23.0",
+                removed_in="0.24.0",
+            )
+        init_project()
+        print("Initialized signac project in current directory.", file=sys.stderr)
     try:
-        return template.init(alias=args.alias, template=args.template)
+        return template.init(template=args.template)
     except OSError as error:
         raise RuntimeError(
             f"Error occurred while trying to initialize a flow project: {error}"
@@ -120,11 +119,8 @@ def main():
         "alias",
         type=str,
         nargs="?",
-        default="project",
-        help="Name of the FlowProject module to initialize. "
-        "This name will also be used to initialize a signac project if "
-        "no signac project was initialized prior to calling 'init'. "
-        "Default value: 'project'.",
+        default="",
+        help="Unused will be removed in flow 0.24.0.",
     )
     parser_init.add_argument(
         "-t",

--- a/flow/project.py
+++ b/flow/project.py
@@ -89,7 +89,7 @@ variable, for example in the project configuration file. The current template di
 {template_dir}
 
 All template variables can be placed within a template using the standard jinja2
-syntax, e.g., the project root directory can be written as: {{{{ project.root_directory() }}}}.
+syntax, e.g., the project root directory can be written as: {{{{ project.path }}}}.
 The available template variables are:
 {template_vars}
 
@@ -984,9 +984,8 @@ class FlowGroup:
         else:
             op_string = operation_name
 
-        root_directory = project.root_directory()
         aggregate_id = get_aggregate_id(aggregate)
-        full_name = f"{root_directory}%{aggregate_id}%{op_string}"
+        full_name = f"{project.path}%{aggregate_id}%{op_string}"
         # The job_op_id is a hash computed from the unique full name.
         job_op_id = md5(full_name.encode("utf-8")).hexdigest()
 
@@ -1569,7 +1568,7 @@ class _FlowProjectClass(type):
                     with jobs[0] as job:
                         if getattr(func, "_flow_cmd", False):
                             return (
-                                f'trap "cd $(pwd)" EXIT && cd {job.ws} && {func(job)}'
+                                f'trap "cd $(pwd)" EXIT && cd {job.path} && {func(job)}'
                             )
                         else:
                             return func(job)
@@ -1761,7 +1760,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
         # the project root directory. This directory may be specified with the 'template_dir'
         # configuration variable.
         self._template_dir = os.path.join(
-            self.root_directory(), self._config.get("template_dir", "templates")
+            self.path, self._config.get("template_dir", "templates")
         )
         self._template_environment_ = {}
 
@@ -2134,7 +2133,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
     def _fn_bundle(self, bundle_id):
         """Return the canonical name to store bundle information."""
-        return os.path.join(self.root_directory(), ".bundles", bundle_id)
+        return os.path.join(self.path, ".bundles", bundle_id)
 
     def _store_bundled(self, operations):
         """Store operation-ids as part of a bundle and return bundle id.
@@ -4838,7 +4837,7 @@ class FlowProject(signac.contrib.Project, metaclass=_FlowProjectClass):
 
         if args.switch_to_project_root:
             with _add_cwd_to_environment_pythonpath():
-                with _switch_to_directory(self.root_directory()):
+                with _switch_to_directory(self.path):
                     run()
         else:
             run()

--- a/flow/template.py
+++ b/flow/template.py
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 
 TEMPLATES = {
     "minimal": [
-        ("{alias}.py", "project_minimal.pyt"),
+        ("project.py", "project_minimal.pyt"),
     ],
     "example": [
-        ("{alias}.py", "project_example.pyt"),
+        ("project.py", "project_example.pyt"),
     ],
     "testing": [
-        ("{alias}.py", "project_testing.pyt"),
+        ("project.py", "project_testing.pyt"),
     ],
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-signac>=1.3.0
+signac>=1.8.0
 jinja2>=3.0.0
 cloudpickle>=1.6.0
 deprecation>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # The core package.
-    "signac>=1.3.0",
+    "signac>=1.8.0",
     # For the templated generation of (submission) scripts.
     "jinja2>=3.0.0",
     # To enable the parallelized execution of operations across processes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,9 +90,7 @@ class TestProjectBase:
         MockScheduler.reset()
         self._tmp_dir = tempfile.TemporaryDirectory(prefix="signac-flow_")
         request.addfinalizer(self._tmp_dir.cleanup)
-        self.project = self.project_class.init_project(
-            name="FlowTestProject", root=self._tmp_dir.name
-        )
+        self.project = self.project_class.init_project(root=self._tmp_dir.name)
         self.cwd = os.getcwd()
 
     def switch_to_cwd(self):
@@ -134,7 +132,7 @@ class TestProjectBase:
         _cmd = f"python {fn_script} {subcmd}"
         try:
             with _add_path_to_environment_pythonpath(os.path.abspath(self.cwd)):
-                with _switch_to_directory(self.project.root_directory()):
+                with _switch_to_directory(self.project.path):
                     return subprocess.check_output(_cmd.split(), stderr=stderr)
         except subprocess.CalledProcessError as error:
             print(error, file=sys.stderr)

--- a/tests/define_status_test_project.py
+++ b/tests/define_status_test_project.py
@@ -39,7 +39,7 @@ def b_is_even(job):
 @_TestProject.pre(b_is_even)
 @_TestProject.post.isfile("world.txt")
 def op1(job):
-    return f'echo "hello" > {job.ws}/world.txt'
+    return f'echo "hello" > {job.path}/world.txt'
 
 
 @group1

--- a/tests/define_test_project.py
+++ b/tests/define_test_project.py
@@ -48,7 +48,7 @@ def b_is_even(job):
 @_TestProject.pre(b_is_even)
 @_TestProject.post.isfile("world.txt")
 def op1(job):
-    return f'echo "hello" > {job.ws}/world.txt'
+    return f'echo "hello" > {job.path}/world.txt'
 
 
 def _need_to_fork(job):

--- a/tests/extract_status.py
+++ b/tests/extract_status.py
@@ -24,7 +24,7 @@ def main(args):
     else:
         return
 
-    p = signac.init_project(name=gen.STATUS_OPTIONS_PROJECT_NAME, root=PROJECT_DIR)
+    p = signac.init_project(root=PROJECT_DIR)
     p.import_from(origin=gen.ARCHIVE_PATH)
 
 

--- a/tests/extract_templates.py
+++ b/tests/extract_templates.py
@@ -24,7 +24,7 @@ def main(args):
     else:
         return
 
-    p = signac.init_project(name=gen.PROJECT_NAME, root=PROJECT_DIR)
+    p = signac.init_project(root=PROJECT_DIR)
     p.import_from(origin=gen.ARCHIVE_DIR)
 
 

--- a/tests/generate_status_reference_data.py
+++ b/tests/generate_status_reference_data.py
@@ -75,7 +75,7 @@ def main(args):
     ) as status_pr:
         init(p)
         init_status_options(status_pr)
-        fp = _TestProject.get_project(root=p.root_directory())
+        fp = _TestProject.get_project(root=p.path)
         env = flow.environment.TestEnvironment
         # We need to set the scheduler manually. The FakeScheduler
         # won't try to call any cluster executable (e.g. squeue)

--- a/tests/generate_template_reference_data.py
+++ b/tests/generate_template_reference_data.py
@@ -172,11 +172,11 @@ def _store_bundled(self, operations):
 def get_masked_flowproject(p, environment=None):
     """Mock environment-dependent attributes and functions. Need to mock
     sys.executable before the FlowProject is instantiated, and then modify the
-    root_directory and project_dir elements after creation."""
+    path and project_dir elements after creation."""
     try:
         old_executable = sys.executable
         sys.executable = MOCK_EXECUTABLE
-        fp = TestProject.get_project(root=p.root_directory())
+        fp = TestProject.get_project(root=p.path)
         if environment is not None:
             fp._environment = environment
         fp._entrypoint.setdefault("path", "generate_template_reference_data.py")
@@ -190,10 +190,10 @@ def get_masked_flowproject(p, environment=None):
             mocking has to happen within this method to avoid affecting other
             methods called during the test that access the project root directory.
             """
-            old_root_directory = fp.root_directory
-            fp.root_directory = lambda: PROJECT_DIRECTORY
+            old_path = fp.path
+            fp._path = PROJECT_DIRECTORY
             operation_id = old_generate_id(self, aggregate, *args, **kwargs)
-            fp.root_directory = old_root_directory
+            fp._path = old_path
             return operation_id
 
         flow.project.FlowGroup._generate_id = wrapped_generate_id

--- a/tests/interactive_template_test.py
+++ b/tests/interactive_template_test.py
@@ -80,7 +80,7 @@ def cli(num_jobs, bundle, parallel, entrypoint):
     with signac.TemporaryProject() as tmp_project:
         for i in range(num_jobs):
             tmp_project.open_job(dict(foo=i)).init()
-        flow_project = Project.get_project(root=tmp_project.root_directory())
+        flow_project = Project.get_project(root=tmp_project.path)
         flow_project._entrypoint.setdefault("path", entrypoint)
 
         partition = ""

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -321,7 +321,7 @@ class TestDirectives:
         self, available_directives_list, non_default_directive_values
     ):
         _tmp_dir = TemporaryDirectory(prefix="flow-directives_")
-        FlowProject.init_project(name="DirectivesTest", root=_tmp_dir.name)
+        FlowProject.init_project(root=_tmp_dir.name)
         project = FlowProject.get_project(root=_tmp_dir.name)
         for i in range(5):
             project.open_job(dict(i=i)).init()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -55,7 +55,7 @@ def setup_project_subprocess_execution(project, stderr_output=sys.stderr):
     Optionally capture stderr with a passed in output or by default output to stderr like normal.
     """
     with _add_cwd_to_environment_pythonpath(), _switch_to_directory(
-        project.root_directory()
+        project.path
     ), redirect_stderr(stderr_output):
         yield
 
@@ -349,7 +349,7 @@ class TestProjectClass(TestProjectBase):
 
         @A.operation(with_job=True)
         def test_context(job):
-            assert os.path.realpath(os.getcwd()) == os.path.realpath(job.ws)
+            assert os.path.realpath(os.getcwd()) == os.path.realpath(job.path)
 
         project = self.mock_project(A)
         with setup_project_subprocess_execution(project):
@@ -2297,7 +2297,7 @@ class TestHooksSetUp(TestProjectBase):
         _cmd = f"python {fn_script} {subcmd} --debug"
         with _add_path_to_environment_pythonpath(os.path.abspath(self.cwd)):
             try:
-                with _switch_to_directory(self.project.root_directory()):
+                with _switch_to_directory(self.project.path):
                     return subprocess.check_output(_cmd.split(), stderr=stderr)
             except subprocess.CalledProcessError as error:
                 print(error, file=sys.stderr)
@@ -2452,7 +2452,7 @@ class TestHooksInvalidOption(TestHooksSetUp):
         _cmd = f"python {fn_script} {subcmd} --debug"
         with _add_path_to_environment_pythonpath(os.path.abspath(self.cwd)):
             try:
-                with _switch_to_directory(self.project.root_directory()):
+                with _switch_to_directory(self.project.path):
                     return subprocess.check_output(_cmd.split(), stderr=stderr)
             except subprocess.CalledProcessError as error:
                 return str(error.output)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -69,17 +69,14 @@ class TestCLI:
 
     def test_init_flowproject(self):
         self.call("python -m flow init".split())
-        assert str(signac.get_project()) == "project"
         assert os.path.exists("project.py")
 
     def test_init_flowproject_alias(self):
-        self.call("python -m flow init my_project".split())
-        assert str(signac.get_project()) == "my_project"
-        assert os.path.exists("my_project.py")
+        self.call("python -m flow init".split())
+        assert os.path.exists("project.py")
 
     def test_init_flowproject_fail_if_exists(self):
         self.call("python -m flow init".split())
-        assert str(signac.get_project()) == "project"
         assert os.path.exists("project.py")
         with pytest.raises(ExitCodeError):
             self.call("python -m flow init".split())
@@ -87,7 +84,6 @@ class TestCLI:
     @pytest.mark.parametrize("template", flow.template.TEMPLATES)
     def test_init_flowproject_template(self, template):
         self.call(f"python -m flow init -t {template}".split())
-        assert str(signac.get_project()) == "project"
         assert os.path.exists("project.py")
 
     @pytest.mark.parametrize(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -16,7 +16,7 @@ def test_print_status():
         name=gen.STATUS_OPTIONS_PROJECT_NAME
     ) as status_pr:
         gen.init(p)
-        fp = gen._TestProject.get_project(root=p.root_directory())
+        fp = gen._TestProject.get_project(root=p.path)
         status_pr.import_from(origin=gen.ARCHIVE_PATH)
         for job in status_pr:
             kwargs = job.statepoint()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
See title. Also updates flow to require at least signac 1.8.0. There will be more breaking changes for 2.0, but we should wait for 2.0 to be released to do that. This also deprecated the usage of `alias` in `flow init` while also rendering it effete.

## Motivation and Context
To make tests pass and remove deprecation warnings.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
