### PR TITLE
Add python 3.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ references:
     key: python-env-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "requirements/requirements-test.txt" }}-{{ checksum ".circleci/ci-oldest-reqs.txt" }}
 
 jobs:
+  linux-python-311: &test-template
+    docker:
+      - image: cimg/python:3.11
+
   linux-python-310: &test-template
     docker:
       - image: cimg/python:3.10
@@ -57,7 +61,7 @@ jobs:
           path: test-reports
           destination: test-reports
 
-  linux-python-310-signac-latest:
+  linux-python-311-signac-latest:
     <<: *test-template
     environment:
       DEPENDENCIES: "NEWEST"
@@ -79,6 +83,29 @@ jobs:
       DEPENDENCIES: "OLDEST"
       SIGNAC_VERSION: "signac==1.8.0"
       PYTHON: python
+
+  test-install-pip-python-311: &test-install-pip
+    docker:
+      - image: cimg/python:3.10
+
+    environment:
+      PYTHON: python
+
+    steps:
+
+      - run:
+          name: install-with-pip
+          command: |
+            ${PYTHON} -m pip install --progress-bar off signac signac-flow
+
+      - run: &smoke-test
+          name: smoke-test
+          command: |
+            ${PYTHON} -m signac --version
+            ${PYTHON} -c 'import signac'
+            ${PYTHON} -m flow --version
+            ${PYTHON} -c 'import flow'
+
 
   test-install-pip-python-310: &test-install-pip
     docker:
@@ -130,6 +157,12 @@ jobs:
 
       - run:
           <<: *smoke-test
+
+  test-install-conda-python-311:
+    <<: *test-install-conda
+    environment:
+      PYTHON_DEP: "python=3.10"
+      PYTHON: python
 
   test-install-conda-python-310:
     <<: *test-install-conda
@@ -195,6 +228,9 @@ workflows:
   version: 2
   test:
     jobs:
+      - linux-python-311:
+          post-steps:
+            - codecov/upload
       - linux-python-310:
           post-steps:
             - codecov/upload
@@ -216,6 +252,7 @@ workflows:
             branches:
               only: /release\/.*/
           requires:
+            - linux-python-311
             - linux-python-310
             - linux-python-39
             - linux-python-38
@@ -229,11 +266,13 @@ workflows:
               only:
                 - master
     jobs:
-      - linux-python-310-signac-latest
+      - linux-python-311-signac-latest
+      - test-install-pip-python-311
       - test-install-pip-python-310
       - test-install-pip-python-39
       - test-install-pip-python-38
       - test-install-conda
+      - test-install-conda-python-311
       - test-install-conda-python-310
       - test-install-conda-python-39
       - test-install-conda-python-38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,10 @@ jobs:
     <<: *test-template
     docker:
       - image: cimg/python:3.9
+  linux-python-38:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.8
   linux-python-38-oldest:
     <<: *test-template
     docker:
@@ -182,6 +186,9 @@ workflows:
       - linux-python-39:
           post-steps:
             - codecov/upload
+      - linux-python-38:
+          post-steps:
+            - codecov/upload
       - linux-python-38-oldest:
           post-steps:
             - codecov/upload
@@ -197,6 +204,7 @@ workflows:
             - linux-python-311
             - linux-python-310
             - linux-python-39
+            - linux-python-38
             - linux-python-38-oldest
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,6 @@ workflows:
       - linux-python-39:
           post-steps:
             - codecov/upload
-      - linux-python-38:
-          post-steps:
-            - codecov/upload
       - linux-python-38-oldest:
           post-steps:
             - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,6 @@ jobs:
     docker:
       - image: cimg/python:3.11
 
-  linux-python-310: &test-template
-    docker:
-      - image: cimg/python:3.10
-
     environment:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "signac"
@@ -67,14 +63,14 @@ jobs:
       DEPENDENCIES: "NEWEST"
       SIGNAC_VERSION: "git+ssh://git@github.com/glotzerlab/signac.git"
       PYTHON: python
+  linux-python-310:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.10
   linux-python-39:
     <<: *test-template
     docker:
       - image: cimg/python:3.9
-  linux-python-38:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.8
   linux-python-38-oldest:
     <<: *test-template
     docker:
@@ -184,7 +180,7 @@ jobs:
 
   check-metadata:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
 
     working_directory: ~/repo
 
@@ -203,7 +199,7 @@ jobs:
 
   test-deploy-pypi:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
       - checkout
@@ -214,7 +210,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       SIGNAC_VERSION: "signac==1.8.0"
       PYTHON: python
 
-  test-install-pip-python-311: &test-install-pip
+  test-install-pip-python-311:
     docker:
       - image: cimg/python:3.11
 
@@ -101,39 +101,6 @@ jobs:
             ${PYTHON} -c 'import signac'
             ${PYTHON} -m flow --version
             ${PYTHON} -c 'import flow'
-
-
-  test-install-pip-python-310: &test-install-pip
-    docker:
-      - image: cimg/python:3.10
-
-    environment:
-      PYTHON: python
-
-    steps:
-
-      - run:
-          name: install-with-pip
-          command: |
-            ${PYTHON} -m pip install --progress-bar off signac signac-flow
-
-      - run: &smoke-test
-          name: smoke-test
-          command: |
-            ${PYTHON} -m signac --version
-            ${PYTHON} -c 'import signac'
-            ${PYTHON} -m flow --version
-            ${PYTHON} -c 'import flow'
-
-  test-install-pip-python-39:
-    <<: *test-install-pip
-    docker:
-      - image: cimg/python:3.9
-
-  test-install-pip-python-38:
-    <<: *test-install-pip
-    docker:
-      - image: cimg/python:3.8
 
   test-install-conda: &test-install-conda
     environment:
@@ -158,24 +125,6 @@ jobs:
     <<: *test-install-conda
     environment:
       PYTHON_DEP: "python=3.11"
-      PYTHON: python
-
-  test-install-conda-python-310:
-    <<: *test-install-conda
-    environment:
-      PYTHON_DEP: "python=3.10"
-      PYTHON: python
-
-  test-install-conda-python-39:
-    <<: *test-install-conda
-    environment:
-      PYTHON_DEP: "python=3.9"
-      PYTHON: python
-
-  test-install-conda-python-38:
-    <<: *test-install-conda
-    environment:
-      PYTHON_DEP: "python=3.8"
       PYTHON: python
 
   check-metadata:
@@ -251,7 +200,6 @@ workflows:
             - linux-python-311
             - linux-python-310
             - linux-python-39
-            - linux-python-38
             - linux-python-38-oldest
   nightly:
     triggers:
@@ -264,14 +212,8 @@ workflows:
     jobs:
       - linux-python-311-signac-latest
       - test-install-pip-python-311
-      - test-install-pip-python-310
-      - test-install-pip-python-39
-      - test-install-pip-python-38
       - test-install-conda
       - test-install-conda-python-311
-      - test-install-conda-python-310
-      - test-install-conda-python-39
-      - test-install-conda-python-38
   deploy:
     jobs:
       - deploy-pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
 
   test-install-pip-python-311: &test-install-pip
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
 
     environment:
       PYTHON: python
@@ -161,7 +161,7 @@ jobs:
   test-install-conda-python-311:
     <<: *test-install-conda
     environment:
-      PYTHON_DEP: "python=3.10"
+      PYTHON_DEP: "python=3.11"
       PYTHON: python
 
   test-install-conda-python-310:

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -101,6 +101,10 @@ class JobStatus(enum.IntEnum):
         except KeyError:
             raise ValueError(f"No equivalent group status for {status}.")
 
+    def __str__(self):
+        """Get the status name as a string."""
+        return self.name
+
 
 class ClusterJob:
     """Class representing a cluster job."""

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Description
Add Python 3.11 to CI.

## Motivation and Context
Python 3.11 go fast :racehorse: .

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.