### PR TITLE
Remove code deprecated in 0.23.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,24 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.24
+============
+
+[0.24.0] -- 20xx-xx-xx
+----------------------
+
+Changed
++++++++
+
+- Placing ``@FlowProject.pre`` and ``@FlowProject.post`` before the ``FlowProject.operation`` decorator raises an error (#700).
+
+Removed
++++++++
+
+- ``@flow.aggregates.aggregator()`` use ``FlowProject.operation(aggregator=...)`` instead (#700).
+- ``alias`` CLI argument to ``flow init`` (#700).
+- ``FlowGroupEntry.with_directives`` use directives keyword argument in ``FlowGroupEntry()``(#700).
+
 Version 0.23
 ============
 
@@ -21,7 +39,7 @@ Added
 Changed
 +++++++
 
-- Deprecated using ``flow.aggregate.aggregator`` as a decorator.
+- Deprecated using ``flow.aggregates.aggregator`` as a decorator.
 - Deprecated placing ``@FlowProject.pre`` and ``@FlowProject.post`` before the ``FlowProject.operation`` decorator (#690).
 - Require ``signac`` version 1.8.0 (#693).
 - Deprecated ``alias`` CLI argument to ``flow init`` (#693).

--- a/flow/__main__.py
+++ b/flow/__main__.py
@@ -19,7 +19,6 @@ import jinja2
 from signac import get_project, init_project
 
 from . import __version__, environment, template
-from .util.misc import _deprecated_warning
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +31,6 @@ def main_init(args):
     try:
         get_project()
     except LookupError:
-        if args.alias != "":
-            _deprecated_warning(
-                deprecation="alias",
-                alternative="",
-                deprecated_in="0.23.0",
-                removed_in="0.24.0",
-            )
         init_project()
         print("Initialized signac project in current directory.", file=sys.stderr)
     try:
@@ -115,13 +107,6 @@ def main():
         "init", help="Initialize a signac-flow project."
     )
     parser_init.set_defaults(func=main_init)
-    parser_init.add_argument(
-        "alias",
-        type=str,
-        nargs="?",
-        default="",
-        help="Unused, will be removed in flow 0.24.0.",
-    )
     parser_init.add_argument(
         "-t",
         "--template",

--- a/flow/aggregates.py
+++ b/flow/aggregates.py
@@ -12,9 +12,6 @@ from abc import abstractmethod
 from collections.abc import Collection, Iterable, Mapping
 from hashlib import md5
 
-from .errors import FlowProjectDefinitionError
-from .util.misc import _deprecated_warning
-
 
 def _get_unique_function_id(func):
     """Generate unique id for the provided function.
@@ -334,40 +331,6 @@ class aggregator:
             return _DefaultAggregateStore(project)
         else:
             return _AggregateStore(self, project)
-
-    def __call__(self, func=None):
-        """Add this aggregator to a provided operation.
-
-        This call operator allows the class to be used as a decorator.
-
-        Parameters
-        ----------
-        func : callable
-            The function to decorate.
-
-        """
-        _deprecated_warning(
-            deprecation="@aggregator(...)",
-            alternative="Use FlowProject.operation(aggregator=aggregator(...)) instead.",
-            deprecated_in="0.23.0",
-            removed_in="0.24.0",
-        )
-        if not callable(func):
-            raise FlowProjectDefinitionError(
-                "Invalid argument passed while calling the aggregate "
-                f"instance. Expected a callable, got {type(func)}."
-            )
-        if getattr(func, "_flow_with_job", False):
-            raise FlowProjectDefinitionError(
-                "The with_job option cannot be used with aggregation."
-            )
-        current_agg = getattr(func, "_flow_aggregate", None)
-        if current_agg is not None and current_agg != aggregator.groupsof(1):
-            raise FlowProjectDefinitionError(
-                "Cannot specify aggregates in function and decorator."
-            )
-        setattr(func, "_flow_aggregate", self)
-        return func
 
 
 class _BaseAggregateStore(Mapping):

--- a/flow/project.py
+++ b/flow/project.py
@@ -65,7 +65,6 @@ from .util.misc import (
     _add_cwd_to_environment_pythonpath,
     _bidict,
     _cached_partial,
-    _deprecated_warning,
     _get_parallel_executor,
     _positive_int,
     _roundrobin,
@@ -731,48 +730,6 @@ class FlowGroupEntry:
         else:
             func._flow_group_operation_directives = {self.name: directives}
 
-    def with_directives(self, directives):
-        """Decorate an operation to provide additional execution directives for this group.
-
-        Directives can be used to provide information about required resources
-        such as the number of processors required for execution of parallelized
-        operations. For a list of supported directives, see
-        :meth:`.FlowProject.operation.with_directives`. For more information,
-        see :ref:`signac-docs:cluster_submission_directives`.
-
-        The directives specified in this decorator are only applied when
-        executing the operation through the :class:`FlowGroup`.
-        To apply directives to an individual operation executed outside of the
-        group, see :meth:`.FlowProject.operation`.
-
-        Note:
-            This method has been deprecated and will be removed in 0.24.0.
-
-        Parameters
-        ----------
-        directives : dict
-            Directives to use for resource requests and execution.
-
-        Returns
-        -------
-        function
-            A decorator which registers the operation with the group using the
-            specified directives.
-        """
-        _deprecated_warning(
-            deprecation="@FlowGroupEntry.with_directives",
-            alternative="Use the directives keyword argument in base decorator e.g. "
-            "@FlowGroupEntry(directives={...}).",
-            deprecated_in="0.23.0",
-            removed_in="0.24.0",
-        )
-
-        def decorator(func):
-            self._set_directives(func, directives)
-            return self(func)
-
-        return decorator
-
 
 class FlowGroup:
     """A :class:`~.FlowGroup` represents a subset of a workflow for a project.
@@ -1317,13 +1274,8 @@ class _FlowProjectClass(type):
                     func for name, func in self._parent_class._collect_operations()
                 ]
                 if func not in operation_functions:
-                    _deprecated_warning(
-                        deprecation="Placing conditions below the @FlowProject.operation "
-                        "decorator.",
-                        alternative="Place decorator above @FlowProject.operation to remove the "
-                        "warning.",
-                        deprecated_in="0.23.0",
-                        removed_in="0.24.0",
+                    raise FlowProjectDefinitionError(
+                        "Conditions must come after (above) @FlowProject.operation."
                     )
                 if self.condition in operation_functions:
                     raise FlowProjectDefinitionError(
@@ -1417,13 +1369,8 @@ class _FlowProjectClass(type):
                     func for name, func in self._parent_class._collect_operations()
                 ]
                 if func not in operation_functions:
-                    _deprecated_warning(
-                        deprecation="Placing conditions below the @FlowProject.operation "
-                        "decorator.",
-                        alternative="Place decorator above @FlowProject.operation to remove the "
-                        "warning.",
-                        deprecated_in="0.23.0",
-                        removed_in="0.24.0",
+                    raise FlowProjectDefinitionError(
+                        "Conditions must come after (above) @FlowProject.operation."
                     )
                 if self.condition in operation_functions:
                     raise FlowProjectDefinitionError(

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -11,9 +11,6 @@ from flow.aggregates import (
     aggregator,
     get_aggregate_id,
 )
-from flow.errors import FlowProjectDefinitionError
-
-ignore_call_warning = pytest.mark.filterwarnings("ignore:@aggregator():FutureWarning")
 
 
 def generate_flow_project():
@@ -346,27 +343,6 @@ class TestAggregate(AggregateProjectSetup, AggregateFixtures):
     def test_invalid_select(self, select):
         with pytest.raises(TypeError):
             aggregator(select=select)
-
-    @ignore_call_warning
-    @pytest.mark.parametrize("param", ["str", 1, None])
-    def test_invalid_call(self, param):
-        aggregator_instance = aggregator()
-        with pytest.raises(FlowProjectDefinitionError):
-            aggregator_instance(param)
-
-    @ignore_call_warning
-    def test_call_without_argument(self):
-        aggregate_instance = aggregator()
-        with pytest.raises(FlowProjectDefinitionError):
-            aggregate_instance()
-
-    @ignore_call_warning
-    def test_call_with_decorator(self):
-        @aggregator()
-        def test_function(x):
-            return x
-
-        assert hasattr(test_function, "_flow_aggregate")
 
     @pytest.mark.parametrize("invalid_value", [{}, "str", -1, -1.5])
     def test_groups_of_invalid_num(self, invalid_value):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -734,13 +734,13 @@ class TestProjectClass(TestProjectBase):
             def op2(job):
                 pass
 
-        with pytest.warns(FutureWarning):
+        with pytest.raises(FlowProjectDefinitionError):
 
             @A.post(condition_fun)
             def op3(job):
                 pass
 
-        with pytest.warns(FutureWarning):
+        with pytest.raises(FlowProjectDefinitionError):
 
             @A.pre(condition_fun)
             def op4(job):
@@ -1711,25 +1711,6 @@ class TestGroupProject(TestProjectBase):
             def foo_operation(job):
                 pass
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*with_directives has been deprecated.*:FutureWarning"
-    )
-    def test_repeat_operation_group_directives_definition(self):
-        """Test that operations cannot be registered with group directives multiple times."""
-
-        class A(FlowProject):
-            pass
-
-        foo_group = A.make_group("foo")
-
-        with pytest.raises(FlowProjectDefinitionError):
-
-            @foo_group.with_directives({"np": 1})
-            @foo_group.with_directives({"np": 1})
-            @A.operation
-            def foo_operation(job):
-                pass
-
     def test_submission_combine_directives(self):
         class A(flow.FlowProject):
             pass
@@ -2067,24 +2048,9 @@ class TestAggregatesProjectBase(TestProjectBase):
         os.chdir(self._tmp_dir.name)
         request.addfinalizer(self.switch_to_cwd)
 
-    @pytest.mark.filterwarnings("ignore:@aggregator():FutureWarning")
     def test_aggregator_with_job(self):
         class A(FlowProject):
             pass
-
-        with pytest.raises(FlowProjectDefinitionError):
-
-            @aggregator()
-            @A.operation(with_job=True)
-            def test_invalid_decorators(job):
-                pass
-
-        with pytest.raises(FlowProjectDefinitionError):
-
-            @A.operation(with_job=True)
-            @aggregator()
-            def test_invalid_decorators_2(job):
-                pass
 
         with pytest.raises(FlowProjectDefinitionError):
 


### PR DESCRIPTION
## Description
Removes all code deprecate in 0.23.0. Refactors tests accordingly. Also raise error on incorrect decorator placement now.

## Motivation and Context
Code was slated for removal.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
