### PR TITLE
Update pydocstyle.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: '6.1.1'
+    rev: '6.3.0'
     hooks:
       - id: pydocstyle
         exclude: |
@@ -39,4 +39,4 @@ repos:
             ^flow/util/mistune/
           )
         additional_dependencies:
-          - toml
+          - tomli


### PR DESCRIPTION
Small bump to pydocstyle version. Mirroring changes from https://github.com/glotzerlab/signac/pull/884.