### PR TITLE
Use main.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,9 @@
 ## Checklist:
 <!-- This checklist must be complete before merging the pull request. -->
 <!-- If you are unsure about any of these items, do not hesitate to ask! -->
-- [ ] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
-- [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
-- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
+- [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
+- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
 - [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
-- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
-- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
+- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
+- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -4,10 +4,10 @@ on:
   # trigger on pull requests
   pull_request:
 
-  # trigger on all commits to master
+  # trigger on all commits to main
   push:
     branches:
-      - 'master'
+      - 'main'
 
   # trigger on request
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ All contributors must agree to the Contributor Agreement ([ContributorAgreement.
 ### Guideline for Code Contributions
 
 * Use the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) model of development:
-  - Both new features and bug fixes should be developed in branches based on `master`.
+  - Both new features and bug fixes should be developed in branches based on `main`.
   - Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
-* Write code that is compatible with all supported versions of Python (listed in [pyproject.toml](https://github.com/glotzerlab/signac/blob/master/pyproject.toml)).
+* Write code that is compatible with all supported versions of Python (listed in [pyproject.toml](https://github.com/glotzerlab/signac/blob/main/pyproject.toml)).
 * Avoid introducing dependencies -- especially those that might be harder to install in high-performance computing environments.
 * Create [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [integration tests](https://en.wikipedia.org/wiki/Integration_testing) that cover the common cases and the corner cases of the code.
 * Preserve backwards-compatibility whenever possible, and make clear if something must change.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# <img src="https://raw.githubusercontent.com/glotzerlab/signac-flow/master/doc/images/palette-header.png" width="75" height="58"> signac-flow - manage workflows with signac
+# <img src="https://raw.githubusercontent.com/glotzerlab/signac-flow/main/doc/images/palette-header.png" width="75" height="58"> signac-flow - manage workflows with signac
 
 [![Affiliated with NumFOCUS](https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/sponsored-projects/affiliated-projects)
 [![PyPI](https://img.shields.io/pypi/v/signac-flow.svg)](https://pypi.org/project/signac-flow/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/signac-flow.svg?style=flat)](https://anaconda.org/conda-forge/signac-flow)
-![CircleCI](https://img.shields.io/circleci/project/github/glotzerlab/signac-flow/master.svg)
 [![RTD](https://img.shields.io/readthedocs/signac.svg?style=flat)](https://docs.signac.io)
-[![License](https://img.shields.io/github/license/glotzerlab/signac-flow.svg)](https://github.com/glotzerlab/signac-flow/blob/master/LICENSE.txt)
+[![License](https://img.shields.io/github/license/glotzerlab/signac-flow.svg)](https://github.com/glotzerlab/signac-flow/blob/main/LICENSE.txt)
 [![PyPI-downloads](https://img.shields.io/pypi/dm/signac-flow.svg?style=flat)](https://pypistats.org/packages/signac-flow)
 [![Slack](https://img.shields.io/badge/Slack-chat%20support-brightgreen.svg?style=flat&logo=slack)](https://signac.io/slack-invite/)
 [![Twitter](https://img.shields.io/twitter/follow/signacdata?style=social)](https://twitter.com/signacdata)

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -19,8 +19,8 @@ This project is open-source.
 Users are highly encouraged to contribute directly by implementing new features and fixing issues.
 Development for packages as part of the **signac** framework should follow the general development guidelines outlined `here <http://docs.signac.io/en/latest/community.html#contributions>`__.
 
-A brief summary of contributing guidelines are outlined in the `CONTRIBUTING.md <https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md>`_ file as part of the repository.
-All contributors must agree to the `Contributor Agreement <https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md>`_ before their pull request can be merged.
+A brief summary of contributing guidelines are outlined in the `CONTRIBUTING.md <https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md>`_ file as part of the repository.
+All contributors must agree to the `Contributor Agreement <https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md>`_ before their pull request can be merged.
 
 Set up a development environment
 --------------------------------
@@ -153,7 +153,7 @@ Before you begin the process, make sure you have the following packages installe
 
 Once you've written the environment class and the template as described above, contributing the environments to the package involves the following:
 
-  1. Create a new branch of **signac-flow** based on the *master* branch.
+  1. Create a new branch of **signac-flow** based on the *main* branch.
   2. Add your environment class to the *flow/environments/* directory, and add the corresponding template to the *flow/templates/* directory.
   3. Run the `tests/test_templates.py` test script. It should fail on your environment, indicating that no reference scripts exist yet.
   4. Update the `environments` dictionary in the `init` function of `tests/generate_template_reference_data.py`. The dictionary indicates the submission argument combinations that need to be tested for your environment.


### PR DESCRIPTION
## Description
Renames `master` to `main` in branch references.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/master/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
