### PR TITLE
Use signac 2.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,17 @@ Changelog
 The **signac-flow** package follows `semantic versioning <https://semver.org/>`_.
 The numbers in brackets denote the related GitHub issue and/or pull request.
 
+Version 0.25
+============
+
+[0.25.0] -- 2023-03-30
+----------------------
+
+Changed
++++++++
+
+- Requires signac 2.0.0 (#734).
+
 Version 0.24
 ============
 
@@ -14,7 +25,7 @@ Version 0.24
 Added
 +++++
 
-- Added the OCLF Crusher environment (#708).
+- Added the OLCF Crusher environment (#708).
 
 Changed
 +++++++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ classifiers = [
 ]
 dependencies = [
     # The core package.
-    # TODO: Test against the released 2.0.0 once available.
-    # "signac>=2.0.0",
-    "signac @ git+https://github.com/glotzerlab/signac@master",
+    "signac>=2.0.0",
     # For the templated generation of (submission) scripts.
     "jinja2>=3.0.0",
     # To enable the parallelized execution of operations across processes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# TODO: Test against the released 2.0.0 once available.
-# signac>=2.0.0
-signac @ git+https://github.com/glotzerlab/signac@master
+signac>=2.0.0
 jinja2>=3.0.0
 cloudpickle>=1.6.0
 deprecation>=2.0.0


### PR DESCRIPTION
## Description
Uses the release of signac 2.0. Closes #711.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
