### PR TITLE
Remove doc-filter after query switched to unified syntax

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,19 @@ The numbers in brackets denote the related GitHub issue and/or pull request.
 Version 0.25
 ============
 
+[0.25.1] -- 2023-XX-XX
+----------------------
+
+Fixed
++++++
+
+- Fix filter argument (#737, #738).
+
+Removed
++++++++
+
+- ``--doc-filter`` argument (#738).
+
 [0.25.0] -- 2023-03-30
 ----------------------
 

--- a/flow/project.py
+++ b/flow/project.py
@@ -4870,11 +4870,7 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
 
     def _select_jobs_from_args(self, args):
         """Select jobs with the given command line arguments ('-j/-f/--job-id')."""
-        if (
-            not args.func == self._main_exec
-            and args.job_id
-            and (args.filter)
-        ):
+        if not args.func == self._main_exec and args.job_id and (args.filter):
             raise ValueError(
                 "Cannot provide both -j/--job-id and -f/--filter in combination."
             )

--- a/flow/project.py
+++ b/flow/project.py
@@ -4223,12 +4223,6 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
             nargs="+",
             help="Only select jobs that match the given state point filter.",
         )
-        parser.add_argument(
-            "--doc-filter",
-            type=str,
-            nargs="+",
-            help="Only select jobs that match the given document filter.",
-        )
 
     @classmethod
     def _add_operation_selection_arg_group(cls, parser):
@@ -4757,7 +4751,6 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
                 "debug",
                 "job_id",
                 "filter",
-                "doc_filter",
             ]
         }
         if args.pop("full"):
@@ -4876,14 +4869,14 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
             operation_function(*aggregate)
 
     def _select_jobs_from_args(self, args):
-        """Select jobs with the given command line arguments ('-j/-f/--doc-filter/--job-id')."""
+        """Select jobs with the given command line arguments ('-j/-f/--job-id')."""
         if (
             not args.func == self._main_exec
             and args.job_id
-            and (args.filter or args.doc_filter)
+            and (args.filter)
         ):
             raise ValueError(
-                "Cannot provide both -j/--job-id and -f/--filter or --doc-filter in combination."
+                "Cannot provide both -j/--job-id and -f/--filter in combination."
             )
 
         if args.job_id:
@@ -4900,12 +4893,11 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
         elif args.func == self._main_exec:
             # exec command does not support filters, so we must exit early.
             return _AggregateStoresCursor(self)
-        elif args.filter or args.doc_filter:
-            # filter or doc_filter provided. Filters can only be used to select
+        elif args.filter:
+            # filter, including doc_filter provided. Filters can only be used to select
             # single jobs and not aggregates of multiple jobs.
             filter_ = parse_filter_arg(args.filter)
-            doc_filter = parse_filter_arg(args.doc_filter)
-            return _JobAggregateCursor(self, filter_, doc_filter)
+            return _JobAggregateCursor(self, filter_)
         else:
             # Use all aggregates
             return _AggregateStoresCursor(self)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1307,6 +1307,18 @@ class TestProjectMainInterface(TestProjectBase):
             else:
                 assert not job.isfile("world.txt")
 
+    def test_main_run_filter(self):
+        assert len(self.project)
+        for job in self.project:
+            assert not job.isfile("world.txt")
+        self.call_subcmd("run -o op1 -f b 2")
+        even_jobs = [job for job in self.project if job.sp.b == 2]
+        for job in self.project:
+            if job in even_jobs:
+                assert job.isfile("world.txt")
+            else:
+                assert not job.isfile("world.txt")
+
     def test_main_run_invalid_op(self):
         assert len(self.project)
         run_output = self.call_subcmd(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #737 

See also https://github.com/glotzerlab/signac/pull/516

However, this conflicts with something [in the changelog](https://github.com/glotzerlab/signac/blob/1472dfa3037c0622b1869c9d3b0479ed8e0fa4f6/changelog.txt#L150):
"Deprecated ``doc_filter`` arguments, which are replaced by namespaced filters. Due to their long history, ``doc_filter`` arguments will still be accepted in signac 2.0 and will only be removed in 3.0 (#516)."

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
