### PR TITLE
fix: Delta hostname regex.

### DIFF
--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -212,9 +212,11 @@ class DeltaEnvironment(DefaultSlurmEnvironment):
 
     # Example hostnames
     # login: dt-login02.delta.internal.ncsa.edu
-    # cpu host: cn001.delta.internal.ncsa.edu
-    # gpu host: gpua075.delta.internal.ncsa.edu
-    hostname_pattern = r"(gpua|dt|cn)(-login)?[0-9]+\.delta\.internal\.ncsa\.edu"
+    # cpu host: cn001.delta.ncsa.illinois.edu
+    # gpu host: gpua049.delta.ncsa.illinois.edu
+    # Avoid full specification of patterns as Delta has a habit of changing hostnames. This should
+    # be safer given the parts listed are less likely to change.
+    hostname_pattern = r"(gpua|dt|cn)(-login)?[0-9]+\.delta.*\.ncsa.*\.edu"
     template = "delta.sh"
     cores_per_node = 128
 


### PR DESCRIPTION
## Description
Delta changed their compute node hostnames in their April 19th maintenance. This fixes the detection of the delta environment.

## Motivation and Context
Fixes environment detection

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
