### PR TITLE
Set Frontier to 56 cores per node.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,14 @@ The numbers in brackets denote the related GitHub issue and/or pull request.
 Version 0.26
 ============
 
+[0.26.1] -- not yet released
+----------------------------
+
+Fixed
++++++
+
+- Schedule 56 cores per node on OLCF Frontier (#764).
+
 [0.26.0] -- 2023-09-06
 ----------------------
 

--- a/flow/environments/incite.py
+++ b/flow/environments/incite.py
@@ -267,7 +267,7 @@ class FrontierEnvironment(DefaultSlurmEnvironment):
 
     hostname_pattern = r".*\.frontier\.olcf\.ornl\.gov"
     template = "frontier.sh"
-    cores_per_node = 64
+    cores_per_node = 56
     gpus_per_node = 8
     mpi_cmd = "srun"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

Set Frontier to 56 cores per node.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Frontier makes 56 cores available per node by default and discourages overriding this: https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#low-noise-mode-layout

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
