### PR TITLE
Fix packaging script files for CLI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,9 +14,7 @@ Version 0.26
 Fixed
 +++++
 
-<<<<<<< HEAD
 - Packaging of files in ``flow.scripts`` used in CLI (#765).
-=======
 - Schedule 56 cores per node on OLCF Frontier (#764).
 
 [0.26.0] -- 2023-09-06

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,6 @@ Fixed
 - Packaging of files in ``flow.scripts`` used in CLI (#765).
 =======
 - Schedule 56 cores per node on OLCF Frontier (#764).
->>>>>>> main
 
 [0.26.0] -- 2023-09-06
 ----------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,14 @@ The numbers in brackets denote the related GitHub issue and/or pull request.
 Version 0.26
 ============
 
+[0.26.1] -- 2023-xx-xx
+----------------------
+
+Fixed
++++++
+
+- Packaging of files in ``flow.scripts`` used in CLI (#765).
+
 [0.26.0] -- 2023-09-06
 ----------------------
 

--- a/flow/scripts/__init__.py
+++ b/flow/scripts/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2023 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+"""Import command line scripts."""


### PR DESCRIPTION
## Description
Adds the necessary `__init__.py` file.

## Motivation and Context
Version 0.26.0 is broken when installing.

__Resolves__: #763

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
