### PR TITLE
Show environment debug print only in verbose mode.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Fixed
 +++++
 
 - Restored static output of non-singleton groups (#773, #774).
+- Show the "Using environment configuration:" message only in verbose output (#776).
 
 Version 0.26
 ============

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,11 +11,14 @@ Version 0.27
 [0.27.0] -- 202x-xx-xx
 ----------------------
 
+Changed
++++++++
+- Show the "Using environment configuration:" message only in verbose output (#776).
+
 Fixed
 +++++
 
 - Restored static output of non-singleton groups (#773, #774).
-- Show the "Using environment configuration:" message only in verbose output (#776).
 
 Version 0.26
 ============

--- a/flow/project.py
+++ b/flow/project.py
@@ -5126,11 +5126,6 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
         )
         self._environment.add_args(env_group)
         parser_submit.set_defaults(func=self._main_submit)
-        print(
-            "Using environment configuration:",
-            self._environment.__name__,
-            file=sys.stderr,
-        )
 
         parser_exec = subparsers.add_parser(
             "exec",
@@ -5176,6 +5171,13 @@ class FlowProject(signac.Project, metaclass=_FlowProjectClass):
 
         # Set verbosity level according to the `-v` argument.
         logging.basicConfig(level=max(0, logging.WARNING - 10 * args.verbose))
+
+        if args.verbose >= 1:
+            print(
+                "Using environment configuration:",
+                self._environment.__name__,
+                file=sys.stderr,
+            )
 
         try:
             args.func(args)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Show the "Using environment configuration:" message only in verbose output.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
By default, hide this output from the typical job on Frontier:
```
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
Using environment configuration: FrontierEnvironment
... 20,000 line output truncated as GitHub limits the size of pull request descriptions
```

Users can request the debug print with `-v` or `--debug`.
## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
