### PR TITLE
Deprecate current directives syntax.

### DIFF
--- a/flow/project.py
+++ b/flow/project.py
@@ -21,6 +21,7 @@ import sys
 import textwrap
 import threading
 import time
+import warnings
 from collections import Counter, defaultdict
 from copy import deepcopy
 from enum import IntFlag
@@ -687,6 +688,12 @@ class FlowGroupEntry:
         func
             The decorated function.
         """
+        if directives is not None:
+            warnings.warn(
+                "The current directives are deprecated as of flow 0.27. When updating flow "
+                "please look at the documentation for the new style.",
+                DeprecationWarning,
+            )
         if func is None:
             return functools.partial(self._internal_call, directives=directives)
         return self._internal_call(func, directives=directives)
@@ -785,6 +792,12 @@ class FlowGroup:
         submit_options="",
         run_options="",
     ):
+        if operation_directives is not None:
+            warnings.warn(
+                "The current directives are deprecated as of flow 0.27. When updating flow "
+                "please look at the documentation for the new style.",
+                DeprecationWarning,
+            )
         self.name = name
         self.submit_options = submit_options
         self.run_options = run_options

--- a/flow/project.py
+++ b/flow/project.py
@@ -690,8 +690,9 @@ class FlowGroupEntry:
         """
         if directives is not None:
             warnings.warn(
-                "The current directives are deprecated as of flow 0.27. When updating flow "
-                "please look at the documentation for the new style.",
+                "The current directives (e.g. nranks, np) are deprecated as of flow 0.27. "
+                "When updating flow please look at the documentation for the new style "
+                "(https://docs.signac.io/en/latest/cluster_submission.html#submission-directives).",
                 DeprecationWarning,
             )
         if func is None:
@@ -794,8 +795,9 @@ class FlowGroup:
     ):
         if operation_directives is not None:
             warnings.warn(
-                "The current directives are deprecated as of flow 0.27. When updating flow "
-                "please look at the documentation for the new style.",
+                "The current directives (e.g. nranks, np) are deprecated as of flow 0.27. "
+                "When updating flow please look at the documentation for the new style "
+                "(https://docs.signac.io/en/latest/cluster_submission.html#submission-directives).",
                 DeprecationWarning,
             )
         self.name = name


### PR DESCRIPTION
## Description
Adds deprecation warnings to the entry points for directives.

## Motivation and Context
In order to make the new directives style possible, we need to remove the current way we handle directives (see #785).

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
