### PR TITLE
Deprecate Stampede2Environment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Added
 
 Changed
 +++++++
+- The Stampede2 environment is deprecated (#798).
 - Show the "Using environment configuration:" message only in verbose output (#776).
 
 Fixed

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -35,6 +35,7 @@ from .scheduling.lsf import LSFScheduler
 from .scheduling.pbs import PBSScheduler
 from .scheduling.simple_scheduler import SimpleScheduler
 from .scheduling.slurm import SlurmScheduler
+from .util.misc import _deprecated_warning
 from .util.template_filters import calc_num_nodes, calc_tasks
 
 logger = logging.getLogger(__name__)
@@ -648,6 +649,43 @@ def registered_environments():
 
 
 def get_environment(test=False):
+    """Attempt to detect the present environment.
+
+    This function iterates through all defined :class:`~.ComputeEnvironment`
+    classes in reversed order of definition and returns the first
+    environment where the :meth:`~.ComputeEnvironment.is_present` method
+    returns True.
+
+    Note
+    ----
+    Environments can be set to raise FutureWarnings by setting a class attribute
+    ``_deprecated`` to ``True``.
+
+    Parameters
+    ----------
+    test : bool
+        Whether to return the TestEnvironment. (Default value = False)
+    import_configured : bool
+        Whether to import environments specified in the flow configuration.
+        (Default value = True)
+
+    Returns
+    -------
+    :class:`~.ComputeEnvironment`
+        The detected environment class.
+
+    """
+    env = _get_environment(test)
+    if getattr(env, "_deprecated", False):
+        _deprecated_warning(
+            deprecation=str(env),
+            alternative="",
+            deprecated_in="v0.27.0",
+            removed_in="v0.28.0",
+        )
+
+
+def _get_environment(test=False):
     """Attempt to detect the present environment.
 
     This function iterates through all defined :class:`~.ComputeEnvironment`

--- a/flow/environment.py
+++ b/flow/environment.py
@@ -683,6 +683,7 @@ def get_environment(test=False):
             deprecated_in="v0.27.0",
             removed_in="v0.28.0",
         )
+    return env
 
 
 def _get_environment(test=False):

--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -21,9 +21,8 @@ _STAMPEDE_OFFSET = os.environ.get("_FLOW_STAMPEDE_OFFSET_`", 0)
 class Stampede2Environment(DefaultSlurmEnvironment):
     """Environment profile for the Stampede2 supercomputer.
 
-    Warning
-    -------
-    This environments is deprecated and will be removed in 0.28.0.
+    .. deprecated:: 0.27.0
+        Stampede2Environment will be removed in 0.28.0.
 
     https://www.tacc.utexas.edu/systems/stampede2
     """

--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -24,6 +24,7 @@ class Stampede2Environment(DefaultSlurmEnvironment):
     https://www.tacc.utexas.edu/systems/stampede2
     """
 
+    _deprecated = True
     hostname_pattern = ".*stampede2"
     template = "stampede2.sh"
     cores_per_node = 48

--- a/flow/environments/xsede.py
+++ b/flow/environments/xsede.py
@@ -21,6 +21,10 @@ _STAMPEDE_OFFSET = os.environ.get("_FLOW_STAMPEDE_OFFSET_`", 0)
 class Stampede2Environment(DefaultSlurmEnvironment):
     """Environment profile for the Stampede2 supercomputer.
 
+    Warning
+    -------
+    This environments is deprecated and will be removed in 0.28.0.
+
     https://www.tacc.utexas.edu/systems/stampede2
     """
 


### PR DESCRIPTION
Also set up system for deprecating environments.

## Motivation and Context
New directives syntax requires removing Stampede2 see #786.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
