### PR TITLE
Move submit command to end of output.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,14 @@ The numbers in brackets denote the related GitHub issue and/or pull request.
 Version 0.27
 ============
 
+[next] -- not yet released
+--------------------------
+
+Changed
++++++++
+
+- Move "Submit command" comment to end of pretend output (#805).
+
 [0.27.0] -- 2024-01-15
 ----------------------
 

--- a/flow/scheduling/base.py
+++ b/flow/scheduling/base.py
@@ -204,9 +204,9 @@ def _call_submit(submit_cmd, script, pretend):
     """
     submit_cmd_string = " ".join(submit_cmd)
     if pretend:
-        print(f"# Submit command: {submit_cmd_string}")
         print(script)
         print()
+        print(f"# Submit command: {submit_cmd_string}")
     else:
         with tempfile.NamedTemporaryFile() as tmp_submit_script:
             tmp_submit_script.write(str(script).encode("utf-8"))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Move the submit command comment (i.e. `# Submit command: sbatch`) to the end of the pretend output.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When testing, it is often convenient to save the output of `submit --pretend` and submit it manually. With `# Submit command: sbatch` as the first line of output, `python project.py submit -n 1 --pretend > file.sh` does produce a valid SLURM script. Moving the comment to the end preserves the information while creating a valid SLURM script that needs no further editing.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
