### PR TITLE
Add jinja2 block around memory options

### DIFF
--- a/flow/templates/slurm.sh
+++ b/flow/templates/slurm.sh
@@ -4,9 +4,11 @@
 #!/bin/bash
 #SBATCH --job-name="{{ id }}"
         {% set memory_requested = operations | calc_memory(parallel)  %}
+{% block memory %}
         {% if memory_requested %}
 #SBATCH --mem={{ memory_requested|format_memory }}
         {% endif %}
+{% endblock memory %}
         {% if partition %}
 #SBATCH --partition={{ partition }}
         {% endif %}

--- a/flow/templates/slurm.sh
+++ b/flow/templates/slurm.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 #SBATCH --job-name="{{ id }}"
         {% set memory_requested = operations | calc_memory(parallel)  %}
-{% block memory %}
+{% block memory scoped %}
         {% if memory_requested %}
 #SBATCH --mem={{ memory_requested|format_memory }}
         {% endif %}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is to enable overriding --mem with --mem-per-gpu or other cluster-specific options.
See discussion at https://github.com/glotzerlab/signac-flow/pull/819#discussion_r1516730936

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-flow/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-flow/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-flow/blob/main/contributors.yaml).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-flow/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-flow/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
